### PR TITLE
feat: add watchlist to track tickers without a position

### DIFF
--- a/electron/db/database.ts
+++ b/electron/db/database.ts
@@ -46,6 +46,19 @@ function runMigrations(database: Database.Database): void {
       color TEXT,
       updated_at TEXT NOT NULL DEFAULT (datetime('now'))
     );
+
+    CREATE TABLE IF NOT EXISTS watchlist (
+      id TEXT PRIMARY KEY,
+      ticker TEXT NOT NULL UNIQUE,
+      company_name TEXT NOT NULL,
+      notes TEXT,
+      sort_order INTEGER NOT NULL DEFAULT 0,
+      added_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_watchlist_ticker ON watchlist(ticker);
+    CREATE INDEX IF NOT EXISTS idx_watchlist_sort_order ON watchlist(sort_order);
   `)
 }
 

--- a/electron/db/watchlist.ts
+++ b/electron/db/watchlist.ts
@@ -1,0 +1,110 @@
+import { randomUUID } from 'crypto'
+import { getDatabase } from './database'
+
+export interface WatchlistRow {
+  readonly id: string
+  readonly ticker: string
+  readonly company_name: string
+  readonly notes: string | null
+  readonly sort_order: number
+  readonly added_at: string
+  readonly updated_at: string
+}
+
+export function getWatchlistItems(): ReadonlyArray<WatchlistRow> {
+  const db = getDatabase()
+  return db.prepare('SELECT * FROM watchlist ORDER BY sort_order ASC, added_at ASC').all() as WatchlistRow[]
+}
+
+export function addWatchlistItem(
+  ticker: string,
+  companyName: string,
+  notes?: string
+): WatchlistRow {
+  const db = getDatabase()
+  const upperTicker = ticker.toUpperCase()
+
+  const existing = db.prepare('SELECT id FROM watchlist WHERE ticker = ?').get(upperTicker) as
+    | { id: string }
+    | undefined
+
+  if (existing) {
+    throw new Error(`${upperTicker} is already on your watchlist`)
+  }
+
+  const maxOrder = db.prepare('SELECT MAX(sort_order) as max_order FROM watchlist').get() as
+    | { max_order: number | null }
+    | undefined
+
+  const nextOrder = (maxOrder?.max_order ?? -1) + 1
+  const id = randomUUID()
+  const now = new Date().toISOString()
+
+  db.prepare(`
+    INSERT INTO watchlist (id, ticker, company_name, notes, sort_order, added_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(id, upperTicker, companyName, notes ?? null, nextOrder, now, now)
+
+  return {
+    id,
+    ticker: upperTicker,
+    company_name: companyName,
+    notes: notes ?? null,
+    sort_order: nextOrder,
+    added_at: now,
+    updated_at: now
+  }
+}
+
+export function removeWatchlistItem(id: string): void {
+  const db = getDatabase()
+  const result = db.prepare('DELETE FROM watchlist WHERE id = ?').run(id)
+  if (result.changes === 0) {
+    throw new Error(`Watchlist item ${id} not found`)
+  }
+}
+
+export function updateWatchlistItem(
+  id: string,
+  updates: { readonly notes?: string | null }
+): WatchlistRow {
+  const db = getDatabase()
+
+  const existing = db.prepare('SELECT * FROM watchlist WHERE id = ?').get(id) as WatchlistRow | undefined
+  if (!existing) {
+    throw new Error(`Watchlist item ${id} not found`)
+  }
+
+  const now = new Date().toISOString()
+  const newNotes = updates.notes !== undefined ? updates.notes : existing.notes
+
+  db.prepare('UPDATE watchlist SET notes = ?, updated_at = ? WHERE id = ?')
+    .run(newNotes, now, id)
+
+  return {
+    ...existing,
+    notes: newNotes,
+    updated_at: now
+  }
+}
+
+export function reorderWatchlistItems(orderedIds: ReadonlyArray<string>): void {
+  const db = getDatabase()
+
+  const updateStmt = db.prepare('UPDATE watchlist SET sort_order = ?, updated_at = ? WHERE id = ?')
+  const now = new Date().toISOString()
+
+  const reorder = db.transaction(() => {
+    orderedIds.forEach((id, index) => {
+      updateStmt.run(index, now, id)
+    })
+  })
+
+  reorder()
+}
+
+export function watchlistItemExists(ticker: string): boolean {
+  const db = getDatabase()
+  const row = db.prepare('SELECT 1 FROM watchlist WHERE ticker = ?').get(ticker.toUpperCase())
+  return row !== undefined
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2,6 +2,13 @@ import { app, BrowserWindow, ipcMain, session } from 'electron'
 import { join } from 'path'
 import { initDatabase, closeDatabase } from './db/database'
 import { addTransaction, updateTransaction, deleteTransaction, getTransactions, getPositions } from './db/positions'
+import {
+  getWatchlistItems,
+  addWatchlistItem,
+  removeWatchlistItem,
+  updateWatchlistItem,
+  reorderWatchlistItems
+} from './db/watchlist'
 import type { NewTransaction, TransactionFilters } from '../src/types/index'
 import { getQuote, getQuotes, getHistoricalPrices, searchTicker, isQuoteStale, getCachedQuote } from './marketData'
 
@@ -97,6 +104,76 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle('market:searchTicker', async (_event, query: string) => {
     return searchTicker(query)
+  })
+
+  ipcMain.handle('db:getWatchlist', () => {
+    const rows = getWatchlistItems()
+    return rows.map((row) => ({
+      id: row.id,
+      ticker: row.ticker,
+      companyName: row.company_name,
+      notes: row.notes,
+      sortOrder: row.sort_order,
+      addedAt: row.added_at,
+      updatedAt: row.updated_at
+    }))
+  })
+
+  ipcMain.handle('db:addWatchlistItem', (_event, item: unknown) => {
+    if (!item || typeof item !== 'object') throw new Error('Invalid input')
+    const { ticker, companyName, notes } = item as Record<string, unknown>
+    if (typeof ticker !== 'string' || ticker.length === 0 || ticker.length > 10) {
+      throw new Error('Invalid ticker')
+    }
+    if (typeof companyName !== 'string' || companyName.length === 0 || companyName.length > 200) {
+      throw new Error('Invalid company name')
+    }
+    if (notes !== undefined && notes !== null && typeof notes !== 'string') {
+      throw new Error('Invalid notes')
+    }
+    const sanitizedNotes = typeof notes === 'string' ? notes.substring(0, 1000) : undefined
+    const row = addWatchlistItem(ticker, companyName, sanitizedNotes)
+    return {
+      id: row.id,
+      ticker: row.ticker,
+      companyName: row.company_name,
+      notes: row.notes,
+      sortOrder: row.sort_order,
+      addedAt: row.added_at,
+      updatedAt: row.updated_at
+    }
+  })
+
+  ipcMain.handle('db:removeWatchlistItem', (_event, id: unknown) => {
+    if (typeof id !== 'string' || id.length === 0) throw new Error('Invalid id')
+    removeWatchlistItem(id)
+  })
+
+  ipcMain.handle('db:updateWatchlistItem', (_event, id: unknown, updates: unknown) => {
+    if (typeof id !== 'string' || id.length === 0) throw new Error('Invalid id')
+    if (!updates || typeof updates !== 'object') throw new Error('Invalid updates')
+    const { notes } = updates as Record<string, unknown>
+    if (notes !== undefined && notes !== null && typeof notes !== 'string') {
+      throw new Error('Invalid notes')
+    }
+    const sanitizedNotes = typeof notes === 'string' ? notes.substring(0, 1000) : (notes as null | undefined)
+    const row = updateWatchlistItem(id, { notes: sanitizedNotes })
+    return {
+      id: row.id,
+      ticker: row.ticker,
+      companyName: row.company_name,
+      notes: row.notes,
+      sortOrder: row.sort_order,
+      addedAt: row.added_at,
+      updatedAt: row.updated_at
+    }
+  })
+
+  ipcMain.handle('db:reorderWatchlist', (_event, orderedIds: unknown) => {
+    if (!Array.isArray(orderedIds) || !orderedIds.every((id) => typeof id === 'string')) {
+      throw new Error('Invalid ordered IDs')
+    }
+    reorderWatchlistItems(orderedIds as string[])
   })
 }
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -11,6 +11,11 @@ export interface ElectronAPI {
   searchTicker: (query: string) => Promise<unknown[]>
   getPositions: () => Promise<unknown[]>
   getPortfolioSummary: () => Promise<unknown>
+  getWatchlist: () => Promise<unknown[]>
+  addWatchlistItem: (item: Record<string, unknown>) => Promise<unknown>
+  removeWatchlistItem: (id: string) => Promise<void>
+  updateWatchlistItem: (id: string, updates: Record<string, unknown>) => Promise<unknown>
+  reorderWatchlist: (orderedIds: string[]) => Promise<void>
 }
 
 const api: ElectronAPI = {
@@ -24,7 +29,12 @@ const api: ElectronAPI = {
     ipcRenderer.invoke('market:getHistoricalPrices', ticker, from, to),
   searchTicker: (query) => ipcRenderer.invoke('market:searchTicker', query),
   getPositions: () => ipcRenderer.invoke('db:getPositions'),
-  getPortfolioSummary: () => ipcRenderer.invoke('db:getPortfolioSummary')
+  getPortfolioSummary: () => ipcRenderer.invoke('db:getPortfolioSummary'),
+  getWatchlist: () => ipcRenderer.invoke('db:getWatchlist'),
+  addWatchlistItem: (item) => ipcRenderer.invoke('db:addWatchlistItem', item),
+  removeWatchlistItem: (id) => ipcRenderer.invoke('db:removeWatchlistItem', id),
+  updateWatchlistItem: (id, updates) => ipcRenderer.invoke('db:updateWatchlistItem', id, updates),
+  reorderWatchlist: (orderedIds) => ipcRenderer.invoke('db:reorderWatchlist', orderedIds)
 }
 
 contextBridge.exposeInMainWorld('electronAPI', api)

--- a/src/components/Layout/Shell.tsx
+++ b/src/components/Layout/Shell.tsx
@@ -8,6 +8,7 @@ import { PositionDetail } from '../Positions/PositionDetail'
 import { CompareView } from '../Views/CompareView'
 import { TransactionsView } from '../Views/TransactionsView'
 import { ClosedPositionsView } from '../Views/ClosedPositionsView'
+import { WatchlistView } from '../Watchlist/WatchlistView'
 
 function renderView(activeView: ViewName) {
   switch (activeView) {
@@ -21,6 +22,8 @@ function renderView(activeView: ViewName) {
       return <TransactionsView />
     case 'closed-positions':
       return <ClosedPositionsView />
+    case 'watchlist':
+      return <WatchlistView />
     default:
       return <DashboardView />
   }

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -58,6 +58,20 @@ function ClosedTradesIcon() {
   )
 }
 
+function WatchlistIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M10 4C5 4 2 10 2 10C2 10 5 16 10 16C15 16 18 10 18 10C18 10 15 4 10 4Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinejoin="round"
+      />
+      <circle cx="10" cy="10" r="3" stroke="currentColor" strokeWidth="1.5" />
+    </svg>
+  )
+}
+
 function CollapseIcon({ collapsed }: { readonly collapsed: boolean }) {
   return (
     <svg
@@ -84,7 +98,8 @@ const NAV_ITEMS: ReadonlyArray<NavItem> = [
   { id: 'position-detail', label: 'Positions', icon: <PositionsIcon /> },
   { id: 'compare', label: 'Compare', icon: <CompareIcon /> },
   { id: 'transactions', label: 'Transactions', icon: <TransactionsIcon /> },
-  { id: 'closed-positions', label: 'Closed Trades', icon: <ClosedTradesIcon /> }
+  { id: 'closed-positions', label: 'Closed Trades', icon: <ClosedTradesIcon /> },
+  { id: 'watchlist', label: 'Watchlist', icon: <WatchlistIcon /> }
 ]
 
 export function Sidebar() {

--- a/src/components/Watchlist/AddToWatchlistModal.tsx
+++ b/src/components/Watchlist/AddToWatchlistModal.tsx
@@ -1,0 +1,221 @@
+import { useState, useEffect, useCallback } from 'react'
+import { TickerSearch } from '../Forms/TickerSearch'
+import { TEXTAREA_CLASS } from '../Forms/formUtils'
+import type { SearchResult, Quote } from '../../types/index'
+
+interface AddToWatchlistModalProps {
+  readonly isOpen: boolean
+  readonly onClose: () => void
+  readonly onAdd: (ticker: string, companyName: string, notes?: string) => Promise<void>
+  readonly existingTickers: ReadonlyArray<string>
+}
+
+interface FormState {
+  readonly ticker: string
+  readonly companyName: string
+  readonly notes: string
+  readonly tickerValidated: boolean
+  readonly currentPrice: number | null
+  readonly dayChange: number | null
+  readonly dayChangePercent: number | null
+}
+
+const INITIAL_FORM: FormState = {
+  ticker: '',
+  companyName: '',
+  notes: '',
+  tickerValidated: false,
+  currentPrice: null,
+  dayChange: null,
+  dayChangePercent: null
+}
+
+export function AddToWatchlistModal({ isOpen, onClose, onAdd, existingTickers }: AddToWatchlistModalProps) {
+  const [form, setForm] = useState<FormState>(INITIAL_FORM)
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  const isDuplicate = form.tickerValidated && existingTickers.includes(form.ticker)
+
+  useEffect(() => {
+    if (isOpen) {
+      setForm(INITIAL_FORM)
+      setError(null)
+      setIsSubmitting(false)
+    }
+  }, [isOpen])
+
+  const fetchQuoteForTicker = useCallback(async (ticker: string) => {
+    try {
+      const quote: Quote = await window.electronAPI.getQuote(ticker)
+      setForm((prev) => ({
+        ...prev,
+        currentPrice: quote.price,
+        dayChange: quote.dayChange,
+        dayChangePercent: quote.dayChangePercent,
+        companyName: quote.companyName || prev.companyName
+      }))
+    } catch {
+      // Quote fetch is best-effort for preview
+    }
+  }, [])
+
+  function handleTickerChange(ticker: string) {
+    setForm((prev) => ({
+      ...prev,
+      ticker,
+      tickerValidated: false,
+      companyName: '',
+      currentPrice: null,
+      dayChange: null,
+      dayChangePercent: null
+    }))
+    setError(null)
+  }
+
+  function handleTickerSelect(result: SearchResult) {
+    setForm((prev) => ({
+      ...prev,
+      ticker: result.ticker,
+      companyName: result.name,
+      tickerValidated: true
+    }))
+    setError(null)
+    fetchQuoteForTicker(result.ticker)
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    setError(null)
+
+    if (!form.tickerValidated) {
+      setError('Select a valid ticker from search results')
+      return
+    }
+
+    if (isDuplicate) {
+      setError(`${form.ticker} is already on your watchlist`)
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      await onAdd(form.ticker, form.companyName, form.notes || undefined)
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add to watchlist')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape' && isOpen) {
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  const changeColor = (form.dayChange ?? 0) >= 0 ? 'text-sv-positive' : 'text-sv-negative'
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className="bg-sv-elevated rounded-lg w-full max-w-md mx-4 shadow-xl border border-sv-border">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-sv-border">
+          <h2 className="text-lg font-semibold text-sv-text">Add to Watchlist</h2>
+          <button
+            onClick={onClose}
+            className="text-sv-text-muted hover:text-sv-text transition-colors cursor-pointer"
+            aria-label="Close"
+          >
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+              <path d="M5 5L15 15M15 5L5 15" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-6 py-4 space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-sv-text-secondary mb-1">Ticker</label>
+            <TickerSearch
+              value={form.ticker}
+              onChange={handleTickerChange}
+              onSelect={handleTickerSelect}
+            />
+            {form.tickerValidated && !isDuplicate && (
+              <div className="mt-2 flex items-center gap-3 text-xs">
+                <span className="text-sv-text-secondary">{form.companyName}</span>
+                {form.currentPrice !== null && (
+                  <>
+                    <span className="font-mono tabular-nums text-sv-text">
+                      ${form.currentPrice.toFixed(2)}
+                    </span>
+                    {form.dayChange !== null && form.dayChangePercent !== null && (
+                      <span className={`font-mono tabular-nums ${changeColor}`}>
+                        {form.dayChange >= 0 ? '+' : ''}
+                        {form.dayChange.toFixed(2)} ({form.dayChangePercent >= 0 ? '+' : ''}
+                        {form.dayChangePercent.toFixed(2)}%)
+                      </span>
+                    )}
+                  </>
+                )}
+              </div>
+            )}
+            {isDuplicate && (
+              <p className="mt-1 text-xs text-sv-warning">
+                {form.ticker} is already on your watchlist
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-sv-text-secondary mb-1">
+              Notes <span className="text-sv-text-muted">(optional)</span>
+            </label>
+            <textarea
+              value={form.notes}
+              onChange={(e) => setForm((prev) => ({ ...prev, notes: e.target.value }))}
+              rows={2}
+              maxLength={1000}
+              placeholder="Why are you watching this ticker?"
+              className={TEXTAREA_CLASS}
+            />
+          </div>
+
+          {error && (
+            <div className="px-3 py-2 rounded-md bg-sv-negative/10 border border-sv-negative/20">
+              <p className="text-sm text-sv-negative">{error}</p>
+            </div>
+          )}
+
+          <div className="flex items-center justify-end gap-3 pt-4 border-t border-sv-border">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-sv-text-secondary hover:text-sv-text bg-sv-surface border border-sv-border rounded-md transition-colors cursor-pointer"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSubmitting || !form.tickerValidated || isDuplicate}
+              className="px-4 py-2 text-sm font-medium text-white rounded-md bg-sv-accent hover:bg-sv-accent/80 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSubmitting ? 'Adding...' : 'Add to Watchlist'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Watchlist/EditNoteModal.tsx
+++ b/src/components/Watchlist/EditNoteModal.tsx
@@ -1,0 +1,103 @@
+import { useState, useEffect, useCallback } from 'react'
+import type { WatchlistItem } from '../../types/index'
+import { TEXTAREA_CLASS } from '../Forms/formUtils'
+
+interface EditNoteModalProps {
+  readonly isOpen: boolean
+  readonly item: WatchlistItem | null
+  readonly onClose: () => void
+  readonly onSave: (id: string, notes: string | null) => Promise<void>
+}
+
+export function EditNoteModal({ isOpen, item, onClose, onSave }: EditNoteModalProps) {
+  const [notes, setNotes] = useState('')
+  const [isSaving, setIsSaving] = useState(false)
+
+  useEffect(() => {
+    if (isOpen && item) {
+      setNotes(item.notes ?? '')
+      setIsSaving(false)
+    }
+  }, [isOpen, item])
+
+  const handleSubmit = useCallback(async (event: React.FormEvent) => {
+    event.preventDefault()
+    if (!item) return
+
+    setIsSaving(true)
+    try {
+      const trimmed = notes.trim()
+      await onSave(item.id, trimmed || null)
+      onClose()
+    } catch {
+      setIsSaving(false)
+    }
+  }, [item, notes, onSave, onClose])
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape' && isOpen) {
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
+  if (!isOpen || !item) return null
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className="bg-sv-elevated rounded-lg w-full max-w-sm mx-4 shadow-xl border border-sv-border">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-sv-border">
+          <h2 className="text-lg font-semibold text-sv-text">
+            Note for <span className="text-sv-accent font-mono">{item.ticker}</span>
+          </h2>
+          <button
+            onClick={onClose}
+            className="text-sv-text-muted hover:text-sv-text transition-colors cursor-pointer"
+            aria-label="Close"
+          >
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+              <path d="M5 5L15 15M15 5L5 15" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-6 py-4 space-y-4">
+          <textarea
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            rows={3}
+            maxLength={1000}
+            placeholder="Add a note about this ticker..."
+            className={TEXTAREA_CLASS}
+            autoFocus
+          />
+
+          <div className="flex items-center justify-end gap-3 pt-4 border-t border-sv-border">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-sv-text-secondary hover:text-sv-text bg-sv-surface border border-sv-border rounded-md transition-colors cursor-pointer"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={isSaving}
+              className="px-4 py-2 text-sm font-medium text-white rounded-md bg-sv-accent hover:bg-sv-accent/80 transition-colors cursor-pointer disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isSaving ? 'Saving...' : 'Save'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Watchlist/WatchlistRow.tsx
+++ b/src/components/Watchlist/WatchlistRow.tsx
@@ -1,0 +1,136 @@
+import { useState, useCallback } from 'react'
+import type { WatchlistItem, Quote } from '../../types/index'
+import { formatCurrency, formatPercent, formatSignedCurrency } from '../../utils/formatters'
+import { FlashValue } from '../common/FlashValue'
+import { WatchlistSparkline } from './WatchlistSparkline'
+
+interface WatchlistRowProps {
+  readonly item: WatchlistItem
+  readonly quote: Quote | null
+  readonly onRemove: (id: string) => void
+  readonly onEditNote: (item: WatchlistItem) => void
+}
+
+function RemoveIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M4 4L12 12M12 4L4 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function NoteIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M3 3h10v10H3z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
+      <path d="M5 6h6M5 8h6M5 10h3" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function getDayChangeColor(change: number): string {
+  if (change > 0) return 'text-sv-positive'
+  if (change < 0) return 'text-sv-negative'
+  return 'text-sv-text-secondary'
+}
+
+export function WatchlistRow({ item, quote, onRemove, onEditNote }: WatchlistRowProps) {
+  const [confirmRemove, setConfirmRemove] = useState(false)
+
+  const handleRemoveClick = useCallback(() => {
+    if (confirmRemove) {
+      onRemove(item.id)
+    } else {
+      setConfirmRemove(true)
+      setTimeout(() => setConfirmRemove(false), 3000)
+    }
+  }, [confirmRemove, item.id, onRemove])
+
+  const price = quote?.price ?? null
+  const dayChange = quote?.dayChange ?? 0
+  const dayChangePercent = quote?.dayChangePercent ?? 0
+  const companyName = quote?.companyName ?? item.companyName
+  const isOffline = quote?.offline === true
+  const isStale = quote?.isStale === true
+
+  return (
+    <tr className="border-b border-sv-border/50 hover:bg-sv-elevated/30 transition-colors group">
+      <td className="px-4 py-3">
+        <div className="flex flex-col">
+          <div className="flex items-center gap-2">
+            <span className="font-mono text-sm font-semibold text-sv-accent tabular-nums">
+              {item.ticker}
+            </span>
+            {(isOffline || isStale) && (
+              <span className="text-[10px] px-1 py-0.5 rounded bg-sv-warning/10 text-sv-warning">
+                {isOffline ? 'OFFLINE' : 'STALE'}
+              </span>
+            )}
+          </div>
+          <span className="text-xs text-sv-text-muted truncate max-w-[180px]">
+            {companyName}
+          </span>
+        </div>
+      </td>
+
+      <td className="px-4 py-3 text-right">
+        {price !== null ? (
+          <FlashValue value={price} className="font-mono text-sm tabular-nums text-sv-text">
+            {formatCurrency(price)}
+          </FlashValue>
+        ) : (
+          <span className="text-sm text-sv-text-muted">&mdash;</span>
+        )}
+      </td>
+
+      <td className="px-4 py-3 text-right">
+        <span className={`font-mono text-sm tabular-nums ${getDayChangeColor(dayChange)}`}>
+          {price !== null ? formatSignedCurrency(dayChange) : '\u2014'}
+        </span>
+      </td>
+
+      <td className="px-4 py-3 text-right">
+        <span className={`font-mono text-sm tabular-nums ${getDayChangeColor(dayChangePercent)}`}>
+          {price !== null ? formatPercent(dayChangePercent) : '\u2014'}
+        </span>
+      </td>
+
+      <td className="px-4 py-3">
+        <WatchlistSparkline ticker={item.ticker} dayChange={dayChange} />
+      </td>
+
+      <td className="px-4 py-3">
+        {item.notes ? (
+          <span className="text-xs text-sv-text-muted truncate max-w-[150px] block" title={item.notes}>
+            {item.notes}
+          </span>
+        ) : (
+          <span className="text-xs text-sv-text-muted/40">&mdash;</span>
+        )}
+      </td>
+
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+          <button
+            onClick={() => onEditNote(item)}
+            className="p-1 rounded text-sv-text-muted hover:text-sv-accent hover:bg-sv-accent/10 transition-colors cursor-pointer"
+            title="Edit note"
+          >
+            <NoteIcon />
+          </button>
+          <button
+            onClick={handleRemoveClick}
+            className={`p-1 rounded transition-colors cursor-pointer ${
+              confirmRemove
+                ? 'text-sv-negative bg-sv-negative/10'
+                : 'text-sv-text-muted hover:text-sv-negative hover:bg-sv-negative/10'
+            }`}
+            title={confirmRemove ? 'Click again to confirm' : 'Remove from watchlist'}
+          >
+            <RemoveIcon />
+          </button>
+        </div>
+      </td>
+    </tr>
+  )
+}

--- a/src/components/Watchlist/WatchlistSparkline.tsx
+++ b/src/components/Watchlist/WatchlistSparkline.tsx
@@ -1,0 +1,93 @@
+import { useState, useEffect } from 'react'
+import { LineChart, Line, YAxis, ResponsiveContainer } from 'recharts'
+import type { PricePoint } from '../../types/index'
+
+interface WatchlistSparklineProps {
+  readonly ticker: string
+  readonly dayChange: number
+}
+
+interface SparklinePoint {
+  readonly date: string
+  readonly close: number
+}
+
+function toSparklineData(prices: ReadonlyArray<PricePoint>): ReadonlyArray<SparklinePoint> {
+  return prices.map((p) => ({ date: p.date, close: p.close }))
+}
+
+function getSparklineStartDate(): string {
+  const date = new Date()
+  date.setDate(date.getDate() - 10)
+  return date.toISOString().split('T')[0] ?? ''
+}
+
+function getToday(): string {
+  return new Date().toISOString().split('T')[0] ?? ''
+}
+
+export function WatchlistSparkline({ ticker, dayChange }: WatchlistSparklineProps) {
+  const [data, setData] = useState<ReadonlyArray<SparklinePoint>>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    setIsLoading(true)
+
+    const fetchData = async () => {
+      try {
+        const from = getSparklineStartDate()
+        const to = getToday()
+        const prices = await window.electronAPI.getHistoricalPrices(ticker, from, to)
+        if (!cancelled) setData(toSparklineData(prices))
+      } catch {
+        if (!cancelled) setData([])
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    fetchData()
+    return () => { cancelled = true }
+  }, [ticker])
+
+  if (isLoading) {
+    return (
+      <div className="w-[80px] h-[32px] flex items-center justify-center">
+        <div className="w-full h-[1px] bg-sv-border" />
+      </div>
+    )
+  }
+
+  if (data.length < 2) {
+    return (
+      <div className="w-[80px] h-[32px] flex items-center justify-center">
+        <span className="text-[10px] text-sv-text-muted">No data</span>
+      </div>
+    )
+  }
+
+  const strokeColor = dayChange >= 0 ? 'var(--color-sv-positive)' : 'var(--color-sv-negative)'
+  const closes = data.map((d) => d.close)
+  const minVal = Math.min(...closes)
+  const maxVal = Math.max(...closes)
+  const padding = (maxVal - minVal) * 0.1 || 1
+
+  return (
+    <div className="w-[80px] h-[32px]">
+      <ResponsiveContainer width="100%" height="100%">
+        <LineChart data={[...data]}>
+          <YAxis domain={[minVal - padding, maxVal + padding]} hide />
+          <Line
+            type="monotone"
+            dataKey="close"
+            stroke={strokeColor}
+            strokeWidth={1.5}
+            dot={false}
+            isAnimationActive={false}
+          />
+        </LineChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/src/components/Watchlist/WatchlistTable.tsx
+++ b/src/components/Watchlist/WatchlistTable.tsx
@@ -1,0 +1,137 @@
+import { useState, useMemo } from 'react'
+import type { WatchlistItem, Quote } from '../../types/index'
+import { WatchlistRow } from './WatchlistRow'
+
+type SortField = 'ticker' | 'price' | 'dayChange' | 'dayChangePercent' | 'sortOrder'
+type SortDirection = 'asc' | 'desc'
+
+interface WatchlistTableProps {
+  readonly items: ReadonlyArray<WatchlistItem>
+  readonly quotes: Readonly<Record<string, Quote>>
+  readonly onRemove: (id: string) => void
+  readonly onEditNote: (item: WatchlistItem) => void
+}
+
+function SortIcon({ active, direction }: { readonly active: boolean; readonly direction: SortDirection }) {
+  if (!active) {
+    return (
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="text-sv-text-muted/40">
+        <path d="M6 2L9 5H3L6 2Z" fill="currentColor" />
+        <path d="M6 10L3 7H9L6 10Z" fill="currentColor" />
+      </svg>
+    )
+  }
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="text-sv-accent">
+      {direction === 'asc' ? (
+        <path d="M6 2L9 5H3L6 2Z" fill="currentColor" />
+      ) : (
+        <path d="M6 10L3 7H9L6 10Z" fill="currentColor" />
+      )}
+    </svg>
+  )
+}
+
+function getQuoteValue(quote: Quote | undefined, field: SortField): number {
+  if (!quote) return -Infinity
+  switch (field) {
+    case 'price':
+      return quote.price
+    case 'dayChange':
+      return quote.dayChange
+    case 'dayChangePercent':
+      return quote.dayChangePercent
+    default:
+      return 0
+  }
+}
+
+export function WatchlistTable({ items, quotes, onRemove, onEditNote }: WatchlistTableProps) {
+  const [sortField, setSortField] = useState<SortField>('sortOrder')
+  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortField(field)
+      setSortDirection(field === 'sortOrder' ? 'asc' : 'desc')
+    }
+  }
+
+  const sortedItems = useMemo(() => {
+    const sorted = [...items].sort((a, b) => {
+      const multiplier = sortDirection === 'asc' ? 1 : -1
+
+      if (sortField === 'sortOrder') {
+        return (a.sortOrder - b.sortOrder) * multiplier
+      }
+
+      if (sortField === 'ticker') {
+        return a.ticker.localeCompare(b.ticker) * multiplier
+      }
+
+      const aVal = getQuoteValue(quotes[a.ticker], sortField)
+      const bVal = getQuoteValue(quotes[b.ticker], sortField)
+      return (aVal - bVal) * multiplier
+    })
+
+    return sorted
+  }, [items, quotes, sortField, sortDirection])
+
+  const headerClass =
+    'px-4 py-2.5 text-xs font-medium text-sv-text-muted uppercase tracking-wider cursor-pointer hover:text-sv-text-secondary transition-colors select-none'
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full">
+        <thead>
+          <tr className="border-b border-sv-border">
+            <th className={`${headerClass} text-left`} onClick={() => handleSort('ticker')}>
+              <div className="flex items-center gap-1">
+                Ticker
+                <SortIcon active={sortField === 'ticker'} direction={sortDirection} />
+              </div>
+            </th>
+            <th className={`${headerClass} text-right`} onClick={() => handleSort('price')}>
+              <div className="flex items-center justify-end gap-1">
+                Price
+                <SortIcon active={sortField === 'price'} direction={sortDirection} />
+              </div>
+            </th>
+            <th className={`${headerClass} text-right`} onClick={() => handleSort('dayChange')}>
+              <div className="flex items-center justify-end gap-1">
+                Change
+                <SortIcon active={sortField === 'dayChange'} direction={sortDirection} />
+              </div>
+            </th>
+            <th className={`${headerClass} text-right`} onClick={() => handleSort('dayChangePercent')}>
+              <div className="flex items-center justify-end gap-1">
+                Change %
+                <SortIcon active={sortField === 'dayChangePercent'} direction={sortDirection} />
+              </div>
+            </th>
+            <th className="px-4 py-2.5 text-xs font-medium text-sv-text-muted uppercase tracking-wider text-left">
+              7D
+            </th>
+            <th className="px-4 py-2.5 text-xs font-medium text-sv-text-muted uppercase tracking-wider text-left">
+              Notes
+            </th>
+            <th className="px-4 py-2.5 w-[80px]" />
+          </tr>
+        </thead>
+        <tbody>
+          {sortedItems.map((item) => (
+            <WatchlistRow
+              key={item.id}
+              item={item}
+              quote={quotes[item.ticker] ?? null}
+              onRemove={onRemove}
+              onEditNote={onEditNote}
+            />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/components/Watchlist/WatchlistView.tsx
+++ b/src/components/Watchlist/WatchlistView.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useState, useCallback, useMemo } from 'react'
+import { useWatchlistStore } from '../../stores/watchlistStore'
+import { useAppStore } from '../../stores/appStore'
+import { WatchlistTable } from './WatchlistTable'
+import { AddToWatchlistModal } from './AddToWatchlistModal'
+import { EditNoteModal } from './EditNoteModal'
+import type { WatchlistItem } from '../../types/index'
+
+function PlusIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M8 3V13M3 8H13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function RefreshIcon({ spinning }: { readonly spinning: boolean }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={spinning ? 'animate-spin' : ''}
+    >
+      <path
+        d="M13.5 8A5.5 5.5 0 1 1 8 2.5"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+      <path d="M12 2.5L8 2.5L10 5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+function EyeIcon() {
+  return (
+    <svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M24 12C14 12 6 24 6 24C6 24 14 36 24 36C34 36 42 24 42 24C42 24 34 12 24 12Z"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinejoin="round"
+      />
+      <circle cx="24" cy="24" r="6" stroke="currentColor" strokeWidth="2" />
+    </svg>
+  )
+}
+
+export function WatchlistView() {
+  const items = useWatchlistStore((s) => s.items)
+  const isLoading = useWatchlistStore((s) => s.isLoading)
+  const error = useWatchlistStore((s) => s.error)
+  const fetchWatchlist = useWatchlistStore((s) => s.fetchWatchlist)
+  const addItem = useWatchlistStore((s) => s.addItem)
+  const removeItem = useWatchlistStore((s) => s.removeItem)
+  const updateItem = useWatchlistStore((s) => s.updateItem)
+  const clearError = useWatchlistStore((s) => s.clearError)
+
+  const quotes = useAppStore((s) => s.quotes)
+  const fetchQuotes = useAppStore((s) => s.fetchQuotes)
+
+  const [addModalOpen, setAddModalOpen] = useState(false)
+  const [editNoteItem, setEditNoteItem] = useState<WatchlistItem | null>(null)
+  const [isRefreshing, setIsRefreshing] = useState(false)
+
+  const existingTickers = useMemo(() => items.map((i) => i.ticker), [items])
+
+  useEffect(() => {
+    fetchWatchlist()
+  }, [fetchWatchlist])
+
+  useEffect(() => {
+    if (items.length === 0) return
+
+    const tickers = items.map((i) => i.ticker)
+    fetchQuotes(tickers).catch(() => {
+      // Quotes will remain empty; sparklines still show cached data
+    })
+  }, [items, fetchQuotes])
+
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true)
+    try {
+      await fetchWatchlist()
+      const freshItems = useWatchlistStore.getState().items
+      const tickers = freshItems.map((i) => i.ticker)
+      if (tickers.length > 0) {
+        await fetchQuotes(tickers)
+      }
+    } catch {
+      // Error state is managed by the store
+    } finally {
+      setIsRefreshing(false)
+    }
+  }, [fetchWatchlist, fetchQuotes])
+
+  const handleAdd = useCallback(async (ticker: string, companyName: string, notes?: string) => {
+    const newItem = await addItem({ ticker, companyName, notes })
+    fetchQuotes([newItem.ticker]).catch(() => {
+      // Best effort
+    })
+  }, [addItem, fetchQuotes])
+
+  const handleRemove = useCallback(async (id: string) => {
+    await removeItem(id)
+  }, [removeItem])
+
+  const handleEditNote = useCallback((item: WatchlistItem) => {
+    setEditNoteItem(item)
+  }, [])
+
+  const handleSaveNote = useCallback(async (id: string, notes: string | null) => {
+    await updateItem(id, { notes })
+  }, [updateItem])
+
+  if (isLoading && items.length === 0) {
+    return (
+      <div className="flex items-center justify-center h-64">
+        <div className="flex items-center gap-3 text-sv-text-secondary">
+          <RefreshIcon spinning />
+          <span className="text-sm">Loading watchlist...</span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold text-sv-text">Watchlist</h1>
+          <p className="text-sm text-sv-text-muted mt-0.5">
+            {items.length} ticker{items.length !== 1 ? 's' : ''} tracked
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={handleRefresh}
+            disabled={isRefreshing}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-sv-text-secondary hover:text-sv-text bg-sv-surface border border-sv-border rounded-md transition-colors cursor-pointer disabled:opacity-50"
+            title="Refresh quotes"
+          >
+            <RefreshIcon spinning={isRefreshing} />
+            <span className="hidden sm:inline">Refresh</span>
+          </button>
+          <button
+            onClick={() => setAddModalOpen(true)}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-white bg-sv-accent hover:bg-sv-accent/80 rounded-md transition-colors cursor-pointer"
+          >
+            <PlusIcon />
+            Add Ticker
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="flex items-center justify-between px-4 py-3 rounded-md bg-sv-negative/10 border border-sv-negative/20">
+          <p className="text-sm text-sv-negative">{error}</p>
+          <button
+            onClick={clearError}
+            className="text-sv-negative/60 hover:text-sv-negative transition-colors cursor-pointer"
+          >
+            <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+              <path d="M4 4L12 12M12 4L4 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+      )}
+
+      {items.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-20 text-sv-text-muted">
+          <EyeIcon />
+          <h2 className="mt-4 text-lg font-medium text-sv-text-secondary">
+            Your watchlist is empty
+          </h2>
+          <p className="mt-1 text-sm text-sv-text-muted text-center max-w-sm">
+            Track tickers you're interested in without needing to hold a position.
+            Add your first ticker to get started.
+          </p>
+          <button
+            onClick={() => setAddModalOpen(true)}
+            className="mt-6 flex items-center gap-1.5 px-4 py-2 text-sm font-medium text-white bg-sv-accent hover:bg-sv-accent/80 rounded-md transition-colors cursor-pointer"
+          >
+            <PlusIcon />
+            Add Your First Ticker
+          </button>
+        </div>
+      ) : (
+        <div className="bg-sv-surface rounded-lg border border-sv-border overflow-hidden">
+          <WatchlistTable
+            items={items}
+            quotes={quotes}
+            onRemove={handleRemove}
+            onEditNote={handleEditNote}
+          />
+        </div>
+      )}
+
+      <AddToWatchlistModal
+        isOpen={addModalOpen}
+        onClose={() => setAddModalOpen(false)}
+        onAdd={handleAdd}
+        existingTickers={existingTickers}
+      />
+
+      <EditNoteModal
+        isOpen={editNoteItem !== null}
+        item={editNoteItem}
+        onClose={() => setEditNoteItem(null)}
+        onSave={handleSaveNote}
+      />
+    </div>
+  )
+}

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import type { Position, Quote, NewTransaction } from '../types/index'
 
-export type ViewName = 'dashboard' | 'position-detail' | 'compare' | 'transactions' | 'closed-positions'
+export type ViewName = 'dashboard' | 'position-detail' | 'compare' | 'transactions' | 'closed-positions' | 'watchlist'
 export type GainStatus = 'all' | 'winners' | 'losers'
 
 export interface FilterState {

--- a/src/stores/watchlistStore.ts
+++ b/src/stores/watchlistStore.ts
@@ -1,0 +1,98 @@
+import { create } from 'zustand'
+import type { WatchlistItem, NewWatchlistItem } from '../types/index'
+
+interface WatchlistState {
+  readonly items: ReadonlyArray<WatchlistItem>
+  readonly isLoading: boolean
+  readonly error: string | null
+}
+
+interface WatchlistActions {
+  readonly fetchWatchlist: () => Promise<void>
+  readonly addItem: (item: NewWatchlistItem) => Promise<WatchlistItem>
+  readonly removeItem: (id: string) => Promise<void>
+  readonly updateItem: (id: string, updates: { notes?: string | null }) => Promise<void>
+  readonly reorderItems: (orderedIds: ReadonlyArray<string>) => Promise<void>
+  readonly clearError: () => void
+}
+
+type WatchlistStore = WatchlistState & WatchlistActions
+
+export const useWatchlistStore = create<WatchlistStore>()((set, get) => ({
+  items: [],
+  isLoading: false,
+  error: null,
+
+  fetchWatchlist: async () => {
+    set({ isLoading: true, error: null })
+    try {
+      const items = await window.electronAPI.getWatchlist()
+      set({ items, isLoading: false })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to fetch watchlist'
+      set({ isLoading: false, error: message })
+      throw new Error(message)
+    }
+  },
+
+  addItem: async (item: NewWatchlistItem) => {
+    try {
+      const newItem = await window.electronAPI.addWatchlistItem(item)
+      set({ items: [...get().items, newItem] })
+      return newItem
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to add watchlist item'
+      set({ error: message })
+      throw new Error(message)
+    }
+  },
+
+  removeItem: async (id: string) => {
+    try {
+      await window.electronAPI.removeWatchlistItem(id)
+      set({ items: get().items.filter((item) => item.id !== id) })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to remove watchlist item'
+      set({ error: message })
+      throw new Error(message)
+    }
+  },
+
+  updateItem: async (id: string, updates: { notes?: string | null }) => {
+    try {
+      const updated = await window.electronAPI.updateWatchlistItem(id, updates)
+      set({
+        items: get().items.map((item) => (item.id === id ? updated : item))
+      })
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Failed to update watchlist item'
+      set({ error: message })
+      throw new Error(message)
+    }
+  },
+
+  reorderItems: async (orderedIds: ReadonlyArray<string>) => {
+    const currentItems = get().items
+    const reordered = orderedIds
+      .map((id, index) => {
+        const item = currentItems.find((i) => i.id === id)
+        return item ? { ...item, sortOrder: index } : null
+      })
+      .filter((item): item is WatchlistItem => item !== null)
+
+    set({ items: reordered })
+
+    try {
+      await window.electronAPI.reorderWatchlist([...orderedIds])
+    } catch (error) {
+      set({ items: currentItems })
+      const message = error instanceof Error ? error.message : 'Failed to reorder watchlist'
+      set({ error: message })
+      throw new Error(message)
+    }
+  },
+
+  clearError: () => {
+    set({ error: null })
+  }
+}))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,6 +11,11 @@ export interface ElectronAPI {
   searchTicker: (query: string) => Promise<SearchResult[]>
   getPositions: () => Promise<Position[]>
   getPortfolioSummary: () => Promise<PortfolioSummary>
+  getWatchlist: () => Promise<WatchlistItem[]>
+  addWatchlistItem: (item: NewWatchlistItem) => Promise<WatchlistItem>
+  removeWatchlistItem: (id: string) => Promise<void>
+  updateWatchlistItem: (id: string, updates: { notes?: string | null }) => Promise<WatchlistItem>
+  reorderWatchlist: (orderedIds: string[]) => Promise<void>
 }
 
 export type TransactionType = 'BUY' | 'SELL'
@@ -100,6 +105,22 @@ export interface TransactionFilters {
   readonly type?: TransactionType
   readonly fromDate?: string
   readonly toDate?: string
+}
+
+export interface WatchlistItem {
+  readonly id: string
+  readonly ticker: string
+  readonly companyName: string
+  readonly notes: string | null
+  readonly sortOrder: number
+  readonly addedAt: string
+  readonly updatedAt: string
+}
+
+export interface NewWatchlistItem {
+  readonly ticker: string
+  readonly companyName: string
+  readonly notes?: string
 }
 
 declare global {


### PR DESCRIPTION
## Summary

Closes #9

- New **Watchlist** view to monitor tickers without holding a position
- Sortable table with live quotes (price, day change, day change %), 7-day sparkline charts, and per-ticker notes
- Add/remove tickers via modal with Yahoo Finance search (reuses existing `TickerSearch`)
- Dedicated Zustand store (`watchlistStore`) for clean separation from portfolio state
- Full IPC input validation on all handlers (type guards, length limits, array validation)
- SQLite `watchlist` table with CRUD operations, sort ordering, and duplicate prevention

## New files (8)
- `electron/db/watchlist.ts` — SQLite CRUD layer
- `src/stores/watchlistStore.ts` — Zustand store
- `src/components/Watchlist/WatchlistView.tsx` — Main view with empty state, refresh, error banner
- `src/components/Watchlist/WatchlistTable.tsx` — Sortable table with column headers
- `src/components/Watchlist/WatchlistRow.tsx` — Row with FlashValue quotes, sparkline, confirm-to-remove
- `src/components/Watchlist/WatchlistSparkline.tsx` — Mini 7-day Recharts line chart
- `src/components/Watchlist/AddToWatchlistModal.tsx` — Add modal with ticker search + duplicate detection
- `src/components/Watchlist/EditNoteModal.tsx` — Quick note editor

## Modified files (7)
- `electron/db/database.ts` — Migration for `watchlist` table
- `electron/main.ts` — 5 new IPC handlers with input validation
- `electron/preload.ts` — contextBridge methods
- `src/types/index.ts` — `WatchlistItem`, `NewWatchlistItem`, `ElectronAPI` updates
- `src/stores/appStore.ts` — `'watchlist'` added to `ViewName`
- `src/components/Layout/Sidebar.tsx` — Watchlist nav item with eye icon
- `src/components/Layout/Shell.tsx` — Watchlist view routing

## Test plan
- [ ] Navigate to Watchlist via sidebar — empty state renders with CTA
- [ ] Add a ticker (e.g., AAPL) — appears in table with live quote and sparkline
- [ ] Add duplicate ticker — warning shown, submit blocked
- [ ] Edit note on a ticker — modal saves and displays truncated note in table
- [ ] Remove a ticker — requires confirm click (3s timeout), then removes
- [ ] Sort by columns (price, change, change %) — toggles asc/desc
- [ ] Refresh button — re-fetches quotes and updates sparklines
- [ ] Offline/stale badge appears when quotes are unavailable
- [ ] Notes limited to 1000 characters in UI and backend