### PR TITLE
feat: add dividend tracking with income dashboard and DRIP support

### DIFF
--- a/electron/db/database.ts
+++ b/electron/db/database.ts
@@ -91,13 +91,34 @@ function runMigrations(database: Database.Database): void {
 
     CREATE INDEX IF NOT EXISTS idx_lot_assignments_sell_tx ON lot_assignments(sell_transaction_id);
     CREATE INDEX IF NOT EXISTS idx_lot_assignments_lot ON lot_assignments(tax_lot_id);
+
+    CREATE TABLE IF NOT EXISTS dividends (
+      id TEXT PRIMARY KEY,
+      ticker TEXT NOT NULL,
+      ex_date TEXT NOT NULL,
+      pay_date TEXT NOT NULL,
+      amount_per_share REAL NOT NULL CHECK(amount_per_share > 0),
+      total_amount REAL NOT NULL CHECK(total_amount > 0),
+      shares_at_date REAL NOT NULL CHECK(shares_at_date > 0),
+      type TEXT NOT NULL CHECK(type IN ('CASH', 'REINVESTED')),
+      linked_transaction_id TEXT REFERENCES transactions(id) ON DELETE SET NULL,
+      notes TEXT,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+
+    CREATE INDEX IF NOT EXISTS idx_dividends_ticker ON dividends(ticker);
+    CREATE INDEX IF NOT EXISTS idx_dividends_ex_date ON dividends(ex_date);
+    CREATE INDEX IF NOT EXISTS idx_dividends_pay_date ON dividends(pay_date);
+    CREATE INDEX IF NOT EXISTS idx_dividends_type ON dividends(type);
   `)
 
   addColumnIfNotExists(database, 'ticker_metadata', 'cost_basis_method', "TEXT NOT NULL DEFAULT 'AVGCOST'")
 }
 
-const ALLOWED_TABLES = new Set(['ticker_metadata', 'transactions', 'tax_lots', 'lot_assignments', 'price_cache', 'watchlist'])
+const ALLOWED_TABLES = new Set(['ticker_metadata', 'transactions', 'tax_lots', 'lot_assignments', 'price_cache', 'watchlist', 'dividends'])
 const IDENTIFIER_PATTERN = /^[a-z_]+$/
+const DEFINITION_PATTERN = /^[A-Z ]+(?:\([^)]+\))?(?:\s+(?:NOT NULL|DEFAULT '[^']*'))*$/
 
 function addColumnIfNotExists(database: Database.Database, table: string, column: string, definition: string): void {
   if (!ALLOWED_TABLES.has(table)) {
@@ -105,6 +126,9 @@ function addColumnIfNotExists(database: Database.Database, table: string, column
   }
   if (!IDENTIFIER_PATTERN.test(column)) {
     throw new Error(`Invalid column name: ${column}`)
+  }
+  if (!DEFINITION_PATTERN.test(definition)) {
+    throw new Error(`Invalid column definition: ${definition}`)
   }
 
   const columns = database.prepare(`PRAGMA table_info(${table})`).all() as ReadonlyArray<{ name: string }>

--- a/electron/db/dividends.ts
+++ b/electron/db/dividends.ts
@@ -1,0 +1,371 @@
+import { randomUUID } from 'crypto'
+import { getDatabase } from './database'
+import { addTransaction } from './positions'
+import type {
+  Dividend,
+  NewDividend,
+  DividendFilters,
+  DividendSummary,
+  PortfolioDividendSummary
+} from '../../src/types/index'
+
+interface DividendRow {
+  readonly id: string
+  readonly ticker: string
+  readonly ex_date: string
+  readonly pay_date: string
+  readonly amount_per_share: number
+  readonly total_amount: number
+  readonly shares_at_date: number
+  readonly type: string
+  readonly linked_transaction_id: string | null
+  readonly notes: string | null
+  readonly created_at: string
+  readonly updated_at: string
+}
+
+function rowToDividend(row: DividendRow): Dividend {
+  return {
+    id: row.id,
+    ticker: row.ticker,
+    exDate: row.ex_date,
+    payDate: row.pay_date,
+    amountPerShare: row.amount_per_share,
+    totalAmount: row.total_amount,
+    sharesAtDate: row.shares_at_date,
+    type: row.type as Dividend['type'],
+    linkedTransactionId: row.linked_transaction_id,
+    notes: row.notes,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  }
+}
+
+export function addDividend(input: NewDividend): Dividend {
+  const db = getDatabase()
+  const id = randomUUID()
+  const now = new Date().toISOString()
+  const ticker = input.ticker.toUpperCase()
+  const totalAmount = input.amountPerShare * input.sharesAtDate
+  const notes = input.notes ?? null
+
+  let linkedTransactionId: string | null = null
+
+  return db.transaction(() => {
+    if (input.type === 'REINVESTED') {
+      const dripPrice = getDripPrice(ticker, input.payDate)
+      if (dripPrice <= 0) {
+        throw new Error(`DRIP price for ${ticker} is invalid (${dripPrice}). Cannot reinvest.`)
+      }
+      const dripShares = totalAmount / dripPrice
+      const dripTransaction = addTransaction({
+        ticker,
+        type: 'BUY',
+        shares: dripShares,
+        price: dripPrice,
+        date: input.payDate,
+        fees: 0,
+        notes: `DRIP reinvestment from ${input.exDate} dividend`
+      })
+      linkedTransactionId = dripTransaction.id
+    }
+
+    db.prepare(`
+      INSERT INTO dividends (id, ticker, ex_date, pay_date, amount_per_share, total_amount, shares_at_date, type, linked_transaction_id, notes, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      id, ticker, input.exDate, input.payDate,
+      input.amountPerShare, totalAmount, input.sharesAtDate,
+      input.type, linkedTransactionId, notes, now, now
+    )
+
+    return {
+      id,
+      ticker,
+      exDate: input.exDate,
+      payDate: input.payDate,
+      amountPerShare: input.amountPerShare,
+      totalAmount,
+      sharesAtDate: input.sharesAtDate,
+      type: input.type,
+      linkedTransactionId,
+      notes,
+      createdAt: now,
+      updatedAt: now
+    }
+  })()
+}
+
+function getDripPrice(ticker: string, payDate: string): number {
+  const db = getDatabase()
+
+  const cached = db.prepare(
+    'SELECT close FROM price_cache WHERE ticker = ? AND date <= ? ORDER BY date DESC LIMIT 1'
+  ).get(ticker, payDate) as { close: number } | undefined
+
+  if (cached) {
+    return cached.close
+  }
+
+  const lastBuy = db.prepare(
+    'SELECT price FROM transactions WHERE ticker = ? AND type = ? AND date <= ? ORDER BY date DESC LIMIT 1'
+  ).get(ticker, 'BUY', payDate) as { price: number } | undefined
+
+  if (lastBuy) {
+    return lastBuy.price
+  }
+
+  throw new Error(
+    `Cannot determine DRIP price for ${ticker} on ${payDate}. No price data available.`
+  )
+}
+
+export function getDividends(filters?: DividendFilters): ReadonlyArray<Dividend> {
+  const db = getDatabase()
+  const conditions: string[] = []
+  const params: unknown[] = []
+
+  if (filters?.ticker) {
+    conditions.push('ticker = ?')
+    params.push(filters.ticker.toUpperCase())
+  }
+  if (filters?.type) {
+    conditions.push('type = ?')
+    params.push(filters.type)
+  }
+  if (filters?.fromDate) {
+    conditions.push('ex_date >= ?')
+    params.push(filters.fromDate)
+  }
+  if (filters?.toDate) {
+    conditions.push('ex_date <= ?')
+    params.push(filters.toDate)
+  }
+
+  const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+  const rows = db.prepare(
+    `SELECT * FROM dividends ${where} ORDER BY ex_date DESC, created_at DESC`
+  ).all(...params) as DividendRow[]
+
+  return rows.map(rowToDividend)
+}
+
+export function updateDividend(id: string, updates: Partial<NewDividend>): Dividend {
+  const db = getDatabase()
+
+  const existing = db.prepare('SELECT * FROM dividends WHERE id = ?').get(id) as DividendRow | undefined
+  if (!existing) {
+    throw new Error(`Dividend ${id} not found`)
+  }
+
+  const ticker = updates.ticker?.toUpperCase() ?? existing.ticker
+  const amountPerShare = updates.amountPerShare ?? existing.amount_per_share
+  const sharesAtDate = updates.sharesAtDate ?? existing.shares_at_date
+  const totalAmount = amountPerShare * sharesAtDate
+  const now = new Date().toISOString()
+
+  const merged = {
+    ticker,
+    exDate: updates.exDate ?? existing.ex_date,
+    payDate: updates.payDate ?? existing.pay_date,
+    amountPerShare,
+    totalAmount,
+    sharesAtDate,
+    type: updates.type ?? existing.type,
+    notes: updates.notes !== undefined ? (updates.notes ?? null) : existing.notes
+  }
+
+  return db.transaction(() => {
+    let linkedTransactionId = existing.linked_transaction_id
+    const typeChanged = merged.type !== existing.type
+
+    if (typeChanged) {
+      if (existing.type === 'REINVESTED' && existing.linked_transaction_id) {
+        db.prepare('DELETE FROM transactions WHERE id = ?').run(existing.linked_transaction_id)
+        linkedTransactionId = null
+      }
+
+      if (merged.type === 'REINVESTED') {
+        const dripPrice = getDripPrice(ticker, merged.payDate)
+        if (dripPrice <= 0) {
+          throw new Error(`DRIP price for ${ticker} is invalid (${dripPrice}). Cannot reinvest.`)
+        }
+        const dripShares = totalAmount / dripPrice
+        const dripTransaction = addTransaction({
+          ticker,
+          type: 'BUY',
+          shares: dripShares,
+          price: dripPrice,
+          date: merged.payDate,
+          fees: 0,
+          notes: `DRIP reinvestment from ${merged.exDate} dividend`
+        })
+        linkedTransactionId = dripTransaction.id
+      }
+    }
+
+    db.prepare(`
+      UPDATE dividends
+      SET ticker = ?, ex_date = ?, pay_date = ?, amount_per_share = ?, total_amount = ?, shares_at_date = ?, type = ?, linked_transaction_id = ?, notes = ?, updated_at = ?
+      WHERE id = ?
+    `).run(
+      merged.ticker, merged.exDate, merged.payDate,
+      merged.amountPerShare, merged.totalAmount, merged.sharesAtDate,
+      merged.type, linkedTransactionId, merged.notes, now, id
+    )
+
+    return {
+      id,
+      ticker: merged.ticker,
+      exDate: merged.exDate,
+      payDate: merged.payDate,
+      amountPerShare: merged.amountPerShare,
+      totalAmount: merged.totalAmount,
+      sharesAtDate: merged.sharesAtDate,
+      type: merged.type as Dividend['type'],
+      linkedTransactionId,
+      notes: merged.notes,
+      createdAt: existing.created_at,
+      updatedAt: now
+    }
+  })()
+}
+
+export function deleteDividend(id: string): void {
+  const db = getDatabase()
+
+  const existing = db.prepare('SELECT * FROM dividends WHERE id = ?').get(id) as DividendRow | undefined
+  if (!existing) {
+    throw new Error(`Dividend ${id} not found`)
+  }
+
+  db.transaction(() => {
+    if (existing.linked_transaction_id) {
+      db.prepare('DELETE FROM transactions WHERE id = ?').run(existing.linked_transaction_id)
+    }
+    db.prepare('DELETE FROM dividends WHERE id = ?').run(id)
+  })()
+}
+
+export function getDividendSummary(): PortfolioDividendSummary {
+  const db = getDatabase()
+  const now = new Date()
+  const yearStart = `${now.getFullYear()}-01-01`
+  const trailing12m = new Date(now)
+  trailing12m.setFullYear(trailing12m.getFullYear() - 1)
+  const trailing12mStr = trailing12m.toISOString().split('T')[0]
+
+  const allDividends = db.prepare(
+    'SELECT * FROM dividends ORDER BY ex_date DESC'
+  ).all() as DividendRow[]
+
+  if (allDividends.length === 0) {
+    return {
+      totalIncomeAllTime: 0,
+      totalIncomeYtd: 0,
+      totalIncomeTrailing12m: 0,
+      totalAnnualizedIncome: 0,
+      averageYield: 0,
+      perTicker: []
+    }
+  }
+
+  const tickerMap = new Map<string, DividendRow[]>()
+  for (const row of allDividends) {
+    const existing = tickerMap.get(row.ticker) ?? []
+    tickerMap.set(row.ticker, [...existing, row])
+  }
+
+  let totalIncomeAllTime = 0
+  let totalIncomeYtd = 0
+  let totalIncomeTrailing12m = 0
+
+  const perTicker: DividendSummary[] = []
+
+  for (const [ticker, rows] of tickerMap) {
+    let tickerTotal = 0
+    let tickerYtd = 0
+    let tickerTrailing12m = 0
+    let lastPayDate: string | null = null
+
+    for (const row of rows) {
+      tickerTotal += row.total_amount
+
+      if (row.pay_date >= yearStart) {
+        tickerYtd += row.total_amount
+      }
+      if (row.pay_date >= trailing12mStr) {
+        tickerTrailing12m += row.total_amount
+      }
+
+      if (lastPayDate === null || row.pay_date > lastPayDate) {
+        lastPayDate = row.pay_date
+      }
+    }
+
+    totalIncomeAllTime += tickerTotal
+    totalIncomeYtd += tickerYtd
+    totalIncomeTrailing12m += tickerTrailing12m
+
+    const metadata = db.prepare(
+      'SELECT company_name FROM ticker_metadata WHERE ticker = ?'
+    ).get(ticker) as { company_name: string | null } | undefined
+
+    const annualizedIncome = computeAnnualizedIncome(rows)
+
+    perTicker.push({
+      ticker,
+      companyName: metadata?.company_name ?? ticker,
+      totalIncome: tickerTotal,
+      ytdIncome: tickerYtd,
+      trailing12mIncome: tickerTrailing12m,
+      paymentCount: rows.length,
+      lastPayDate,
+      annualizedIncome,
+      dividendYield: 0
+    })
+  }
+
+  const totalAnnualizedIncome = perTicker.reduce(
+    (sum, s) => sum + s.annualizedIncome, 0
+  )
+
+  return {
+    totalIncomeAllTime,
+    totalIncomeYtd,
+    totalIncomeTrailing12m,
+    totalAnnualizedIncome,
+    averageYield: 0,
+    perTicker
+  }
+}
+
+function computeAnnualizedIncome(rows: ReadonlyArray<DividendRow>): number {
+  if (rows.length === 0) {
+    return 0
+  }
+  if (rows.length === 1) {
+    // Single payment — return as-is; insufficient data to annualize
+    return rows[0].total_amount
+  }
+
+  const sorted = [...rows].sort((a, b) => a.pay_date.localeCompare(b.pay_date))
+  const earliest = new Date(sorted[0].pay_date)
+  const latest = new Date(sorted[sorted.length - 1].pay_date)
+  const daySpan = (latest.getTime() - earliest.getTime()) / (1000 * 60 * 60 * 24)
+
+  if (daySpan <= 0) {
+    return rows.reduce((sum, r) => sum + r.total_amount, 0)
+  }
+
+  const totalIncome = rows.reduce((sum, r) => sum + r.total_amount, 0)
+  return (totalIncome / daySpan) * 365
+}
+
+export function getTotalDividendIncome(): number {
+  const db = getDatabase()
+  const result = db.prepare(
+    'SELECT COALESCE(SUM(total_amount), 0) as total FROM dividends'
+  ).get() as { total: number }
+  return result.total
+}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -20,8 +20,15 @@ import {
 } from './db/taxLots'
 import { runTaxLotBackfill } from './db/taxLotMigration'
 import { generateTaxReport, generateTaxReportCsv } from './db/taxReport'
-import type { NewTransaction, TransactionFilters, CostBasisMethod } from '../src/types/index'
-import { getQuote, getQuotes, getHistoricalPrices, searchTicker, isQuoteStale, getCachedQuote } from './marketData'
+import {
+  addDividend,
+  getDividends,
+  updateDividend,
+  deleteDividend,
+  getDividendSummary
+} from './db/dividends'
+import type { NewTransaction, TransactionFilters, CostBasisMethod, NewDividend, DividendFilters } from '../src/types/index'
+import { getQuote, getQuotes, getHistoricalPrices, searchTicker, isQuoteStale, getCachedQuote, getDividendHistory, getDividendInfo } from './marketData'
 
 function createWindow(): BrowserWindow {
   const win = new BrowserWindow({
@@ -56,6 +63,17 @@ function validateTransactionInput(tx: unknown): void {
   if (typeof shares !== 'number' || shares <= 0) throw new Error('Invalid shares')
   if (typeof price !== 'number' || price <= 0) throw new Error('Invalid price')
   if (typeof date !== 'string' || date.length === 0) throw new Error('Invalid date')
+}
+
+function validateDividendInput(input: unknown): void {
+  if (!input || typeof input !== 'object') throw new Error('Invalid input')
+  const { ticker, exDate, payDate, amountPerShare, sharesAtDate, type } = input as Record<string, unknown>
+  if (typeof ticker !== 'string' || ticker.length === 0 || ticker.length > 10) throw new Error('Invalid ticker')
+  if (typeof exDate !== 'string' || exDate.length === 0) throw new Error('Invalid ex-date')
+  if (typeof payDate !== 'string' || payDate.length === 0) throw new Error('Invalid pay date')
+  if (typeof amountPerShare !== 'number' || amountPerShare <= 0) throw new Error('Invalid amount per share')
+  if (typeof sharesAtDate !== 'number' || sharesAtDate <= 0) throw new Error('Invalid shares')
+  if (type !== 'CASH' && type !== 'REINVESTED') throw new Error('Invalid dividend type')
 }
 
 function registerIpcHandlers(): void {
@@ -97,7 +115,6 @@ function registerIpcHandlers(): void {
   })
 
   ipcMain.handle('db:getPortfolioSummary', () => {
-    // Stub — full implementation in Task 5 (Zustand store) with market data
     return {
       totalValue: 0,
       totalCost: 0,
@@ -106,6 +123,7 @@ function registerIpcHandlers(): void {
       totalUnrealizedGain: 0,
       totalUnrealizedGainPercent: 0,
       totalRealizedGain: 0,
+      totalDividendIncome: 0,
       totalReturn: 0,
       totalReturnPercent: 0,
       positionCount: 0
@@ -265,6 +283,56 @@ function registerIpcHandlers(): void {
       throw new Error('Invalid ordered IDs')
     }
     reorderWatchlistItems(orderedIds as string[])
+  })
+
+  ipcMain.handle('db:getDividends', (_event, filters?: unknown) => {
+    if (filters !== undefined) {
+      if (typeof filters !== 'object' || filters === null) throw new Error('Invalid filters')
+      const f = filters as Record<string, unknown>
+      if (f.ticker !== undefined && (typeof f.ticker !== 'string' || f.ticker.length === 0)) throw new Error('Invalid ticker filter')
+      if (f.type !== undefined && f.type !== 'CASH' && f.type !== 'REINVESTED') throw new Error('Invalid type filter')
+      if (f.fromDate !== undefined && typeof f.fromDate !== 'string') throw new Error('Invalid fromDate filter')
+      if (f.toDate !== undefined && typeof f.toDate !== 'string') throw new Error('Invalid toDate filter')
+    }
+    return getDividends(filters as DividendFilters | undefined)
+  })
+
+  ipcMain.handle('db:addDividend', (_event, input: unknown) => {
+    validateDividendInput(input)
+    return addDividend(input as NewDividend)
+  })
+
+  ipcMain.handle('db:updateDividend', (_event, id: unknown, updates: unknown) => {
+    if (typeof id !== 'string' || id.length === 0) throw new Error('Invalid id')
+    if (!updates || typeof updates !== 'object') throw new Error('Invalid updates')
+    const u = updates as Record<string, unknown>
+    if (u.ticker !== undefined && (typeof u.ticker !== 'string' || u.ticker.length === 0 || u.ticker.length > 10)) throw new Error('Invalid ticker')
+    if (u.amountPerShare !== undefined && (typeof u.amountPerShare !== 'number' || u.amountPerShare <= 0)) throw new Error('Invalid amount per share')
+    if (u.sharesAtDate !== undefined && (typeof u.sharesAtDate !== 'number' || u.sharesAtDate <= 0)) throw new Error('Invalid shares')
+    if (u.type !== undefined && u.type !== 'CASH' && u.type !== 'REINVESTED') throw new Error('Invalid dividend type')
+    if (u.exDate !== undefined && (typeof u.exDate !== 'string' || u.exDate.length === 0)) throw new Error('Invalid ex-date')
+    if (u.payDate !== undefined && (typeof u.payDate !== 'string' || u.payDate.length === 0)) throw new Error('Invalid pay date')
+    return updateDividend(id, updates as Partial<NewDividend>)
+  })
+
+  ipcMain.handle('db:deleteDividend', (_event, id: unknown) => {
+    if (typeof id !== 'string' || id.length === 0) throw new Error('Invalid id')
+    deleteDividend(id)
+  })
+
+  ipcMain.handle('db:getDividendSummary', () => {
+    return getDividendSummary()
+  })
+
+  ipcMain.handle('market:getDividendHistory', async (_event, ticker: string, from?: string) => {
+    if (typeof ticker !== 'string' || ticker.length === 0) throw new Error('Invalid ticker')
+    if (from !== undefined && typeof from !== 'string') throw new Error('Invalid from date')
+    return getDividendHistory(ticker, from)
+  })
+
+  ipcMain.handle('market:getDividendInfo', async (_event, ticker: string) => {
+    if (typeof ticker !== 'string' || ticker.length === 0) throw new Error('Invalid ticker')
+    return getDividendInfo(ticker)
   })
 }
 

--- a/electron/marketData.ts
+++ b/electron/marketData.ts
@@ -14,7 +14,7 @@ import {
   getTickerMetadata
 } from './db/priceCache'
 import { getTickerColor } from '../src/utils/colors'
-import type { Quote, PricePoint, SearchResult } from '../src/types/index'
+import type { Quote, PricePoint, SearchResult, DividendHistoryEntry, DividendInfo } from '../src/types/index'
 
 const STALE_THRESHOLD = 15 * 60 * 1000
 const RATE_LIMIT_DELAY = 200
@@ -274,4 +274,57 @@ export function isQuoteStale(ticker: string): boolean {
 export function getCachedQuote(ticker: string): Quote | null {
   const entry = quoteCache.get(ticker.toUpperCase())
   return entry?.quote ?? null
+}
+
+export async function getDividendHistory(
+  ticker: string,
+  from?: string
+): Promise<ReadonlyArray<DividendHistoryEntry>> {
+  const upperTicker = ticker.toUpperCase()
+  const period1 = from ?? '2000-01-01'
+
+  try {
+    const rows = await yahooFinance.historical(upperTicker, {
+      period1,
+      events: 'dividends'
+    })
+
+    return rows.map((row) => ({
+      date: formatDate(row.date),
+      amount: (row as unknown as { dividends: number }).dividends
+    }))
+  } catch (error) {
+    throw new Error(
+      `Failed to fetch dividend history for ${upperTicker}: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
+}
+
+export async function getDividendInfo(ticker: string): Promise<DividendInfo> {
+  const upperTicker = ticker.toUpperCase()
+
+  try {
+    const summary = await yahooFinance.quoteSummary(upperTicker, {
+      modules: ['summaryDetail']
+    })
+
+    const detail = summary.summaryDetail
+    const exDateRaw = detail?.exDividendDate
+
+    return {
+      dividendRate: detail?.dividendRate ?? null,
+      dividendYield: detail?.dividendYield != null ? detail.dividendYield * 100 : null,
+      exDividendDate: exDateRaw ? formatDate(exDateRaw) : null,
+      fiveYearAvgDividendYield: detail?.fiveYearAvgDividendYield ?? null,
+      payoutRatio: detail?.payoutRatio != null ? detail.payoutRatio * 100 : null,
+      trailingAnnualDividendRate: detail?.trailingAnnualDividendRate ?? null,
+      trailingAnnualDividendYield: detail?.trailingAnnualDividendYield != null
+        ? detail.trailingAnnualDividendYield * 100
+        : null
+    }
+  } catch (error) {
+    throw new Error(
+      `Failed to fetch dividend info for ${upperTicker}: ${error instanceof Error ? error.message : String(error)}`
+    )
+  }
 }

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -24,6 +24,13 @@ export interface ElectronAPI {
   generateTaxReport: (year?: number) => Promise<unknown>
   exportTaxReportCsv: (year?: number) => Promise<string>
   addTransactionWithLots: (tx: Record<string, unknown>, lotSelections?: ReadonlyArray<{ lotId: string; shares: number }>) => Promise<unknown>
+  getDividends: (filters?: Record<string, unknown>) => Promise<unknown[]>
+  addDividend: (input: Record<string, unknown>) => Promise<unknown>
+  updateDividend: (id: string, updates: Record<string, unknown>) => Promise<unknown>
+  deleteDividend: (id: string) => Promise<void>
+  getDividendSummary: () => Promise<unknown>
+  getDividendHistory: (ticker: string, from?: string) => Promise<unknown[]>
+  getDividendInfo: (ticker: string) => Promise<unknown>
 }
 
 const api: ElectronAPI = {
@@ -50,7 +57,14 @@ const api: ElectronAPI = {
   getCostBasisMethod: (ticker) => ipcRenderer.invoke('db:getCostBasisMethod', ticker),
   generateTaxReport: (year) => ipcRenderer.invoke('db:generateTaxReport', year),
   exportTaxReportCsv: (year) => ipcRenderer.invoke('db:exportTaxReportCsv', year),
-  addTransactionWithLots: (tx, lotSelections) => ipcRenderer.invoke('db:addTransactionWithLots', tx, lotSelections)
+  addTransactionWithLots: (tx, lotSelections) => ipcRenderer.invoke('db:addTransactionWithLots', tx, lotSelections),
+  getDividends: (filters) => ipcRenderer.invoke('db:getDividends', filters),
+  addDividend: (input) => ipcRenderer.invoke('db:addDividend', input),
+  updateDividend: (id, updates) => ipcRenderer.invoke('db:updateDividend', id, updates),
+  deleteDividend: (id) => ipcRenderer.invoke('db:deleteDividend', id),
+  getDividendSummary: () => ipcRenderer.invoke('db:getDividendSummary'),
+  getDividendHistory: (ticker, from) => ipcRenderer.invoke('market:getDividendHistory', ticker, from),
+  getDividendInfo: (ticker) => ipcRenderer.invoke('market:getDividendInfo', ticker)
 }
 
 contextBridge.exposeInMainWorld('electronAPI', api)

--- a/src/components/Dividends/AddDividendModal.tsx
+++ b/src/components/Dividends/AddDividendModal.tsx
@@ -1,0 +1,405 @@
+import { useState, useEffect, useCallback } from 'react'
+import { useDividendStore } from '../../stores/dividendStore'
+import { useAppStore } from '../../stores/appStore'
+import { TickerSearch } from '../Forms/TickerSearch'
+import { INPUT_CLASS, INPUT_CLASS_NO_MONO, TEXTAREA_CLASS } from '../Forms/formUtils'
+import type { DividendType, SearchResult, Quote } from '../../types/index'
+
+interface AddDividendModalProps {
+  readonly isOpen: boolean
+  readonly onClose: () => void
+  readonly prefillTicker?: string
+}
+
+interface FormState {
+  readonly ticker: string
+  readonly exDate: string
+  readonly payDate: string
+  readonly amountPerShare: string
+  readonly sharesAtDate: string
+  readonly type: DividendType
+  readonly notes: string
+  readonly companyName: string
+  readonly tickerValidated: boolean
+}
+
+interface FormErrors {
+  readonly ticker?: string
+  readonly exDate?: string
+  readonly payDate?: string
+  readonly amountPerShare?: string
+  readonly sharesAtDate?: string
+}
+
+function getTodayString(): string {
+  return new Date().toISOString().split('T')[0]
+}
+
+function createInitialState(prefillTicker?: string, prefillShares?: number): FormState {
+  const today = getTodayString()
+  return {
+    ticker: prefillTicker ?? '',
+    exDate: today,
+    payDate: today,
+    amountPerShare: '',
+    sharesAtDate: prefillShares ? String(prefillShares) : '',
+    type: 'CASH',
+    notes: '',
+    companyName: '',
+    tickerValidated: !!prefillTicker
+  }
+}
+
+function validateForm(form: FormState): FormErrors {
+  const errors: Record<string, string> = {}
+
+  if (!form.tickerValidated) {
+    errors.ticker = 'Select a valid ticker from search results'
+  }
+
+  if (!form.exDate) {
+    errors.exDate = 'Ex-date is required'
+  } else if (new Date(form.exDate) > new Date()) {
+    errors.exDate = 'Ex-date cannot be in the future'
+  }
+
+  if (!form.payDate) {
+    errors.payDate = 'Pay date is required'
+  }
+
+  const amount = parseFloat(form.amountPerShare)
+  if (!form.amountPerShare || isNaN(amount) || amount <= 0) {
+    errors.amountPerShare = 'Amount per share must be greater than 0'
+  }
+
+  const shares = parseFloat(form.sharesAtDate)
+  if (!form.sharesAtDate || isNaN(shares) || shares <= 0) {
+    errors.sharesAtDate = 'Shares must be greater than 0'
+  }
+
+  return errors as FormErrors
+}
+
+export function AddDividendModal({ isOpen, onClose, prefillTicker }: AddDividendModalProps) {
+  const positions = useAppStore((s) => s.positions)
+  const addDividend = useDividendStore((s) => s.addDividend)
+  const fetchPositions = useAppStore((s) => s.fetchPositions)
+
+  const prefillPosition = prefillTicker
+    ? positions.find((p) => p.ticker === prefillTicker)
+    : undefined
+
+  const [form, setForm] = useState<FormState>(() =>
+    createInitialState(prefillTicker, prefillPosition?.totalShares)
+  )
+  const [errors, setErrors] = useState<FormErrors>({})
+  const [submitError, setSubmitError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (isOpen) {
+      const pos = prefillTicker
+        ? positions.find((p) => p.ticker === prefillTicker)
+        : undefined
+      setForm(createInitialState(prefillTicker, pos?.totalShares))
+      setErrors({})
+      setSubmitError(null)
+      setIsSubmitting(false)
+    }
+  }, [isOpen, prefillTicker, positions])
+
+  const fetchQuoteForTicker = useCallback(async (ticker: string) => {
+    try {
+      const quote: Quote = await window.electronAPI.getQuote(ticker)
+      const pos = positions.find((p) => p.ticker === quote.ticker)
+      setForm((prev) => ({
+        ...prev,
+        ticker: quote.ticker,
+        companyName: quote.companyName,
+        tickerValidated: true,
+        sharesAtDate: pos ? String(pos.totalShares) : prev.sharesAtDate
+      }))
+    } catch {
+      setForm((prev) => ({
+        ...prev,
+        tickerValidated: false,
+        companyName: ''
+      }))
+    }
+  }, [positions])
+
+  useEffect(() => {
+    if (isOpen && prefillTicker) {
+      fetchQuoteForTicker(prefillTicker)
+    }
+  }, [isOpen, prefillTicker, fetchQuoteForTicker])
+
+  function updateField<K extends keyof FormState>(key: K, value: FormState[K]) {
+    setForm((prev) => ({ ...prev, [key]: value }))
+    setErrors((prev) => {
+      const { [key as keyof FormErrors]: _, ...rest } = prev as Record<string, string | undefined>
+      return rest as FormErrors
+    })
+  }
+
+  function handleTickerChange(ticker: string) {
+    setForm((prev) => ({
+      ...prev,
+      ticker,
+      tickerValidated: false,
+      companyName: ''
+    }))
+  }
+
+  function handleTickerSelect(result: SearchResult) {
+    setForm((prev) => ({
+      ...prev,
+      ticker: result.ticker,
+      companyName: result.name,
+      tickerValidated: true
+    }))
+    fetchQuoteForTicker(result.ticker)
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    setSubmitError(null)
+
+    const validationErrors = validateForm(form)
+    if (Object.keys(validationErrors).length > 0) {
+      setErrors(validationErrors)
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      await addDividend({
+        ticker: form.ticker,
+        exDate: form.exDate,
+        payDate: form.payDate,
+        amountPerShare: parseFloat(form.amountPerShare),
+        sharesAtDate: parseFloat(form.sharesAtDate),
+        type: form.type,
+        notes: form.notes || undefined
+      })
+
+      if (form.type === 'REINVESTED') {
+        await fetchPositions()
+      }
+
+      onClose()
+    } catch (error) {
+      setSubmitError(error instanceof Error ? error.message : 'Failed to add dividend')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape' && isOpen) {
+        onClose()
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen, onClose])
+
+  if (!isOpen) return null
+
+  const totalAmount = form.amountPerShare && form.sharesAtDate
+    ? (parseFloat(form.amountPerShare) * parseFloat(form.sharesAtDate))
+    : 0
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div className="bg-sv-elevated rounded-lg w-full max-w-md mx-4 shadow-xl border border-sv-border">
+        <div className="flex items-center justify-between px-6 py-4 border-b border-sv-border">
+          <h2 className="text-lg font-semibold text-sv-text">Record Dividend</h2>
+          <button
+            onClick={onClose}
+            className="text-sv-text-muted hover:text-sv-text transition-colors cursor-pointer"
+            aria-label="Close"
+          >
+            <svg width="20" height="20" viewBox="0 0 20 20" fill="none">
+              <path d="M5 5L15 15M15 5L5 15" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+            </svg>
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="px-6 py-4 space-y-4 max-h-[70vh] overflow-y-auto">
+          <div>
+            <label className="block text-sm font-medium text-sv-text-secondary mb-1">Ticker</label>
+            {prefillTicker ? (
+              <div className="flex items-center gap-2 px-3 py-2 rounded-md bg-sv-surface border border-sv-border">
+                <span className="text-sm font-semibold text-sv-text">{form.ticker}</span>
+                <span className="text-xs text-sv-text-muted">{form.companyName}</span>
+              </div>
+            ) : (
+              <TickerSearch
+                value={form.ticker}
+                onChange={handleTickerChange}
+                onSelect={handleTickerSelect}
+              />
+            )}
+            {errors.ticker && (
+              <p className="mt-1 text-xs text-sv-negative">{errors.ticker}</p>
+            )}
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-sv-text-secondary mb-1">Type</label>
+            <div className="flex rounded-md overflow-hidden border border-sv-border">
+              <button
+                type="button"
+                onClick={() => updateField('type', 'CASH')}
+                className={`
+                  flex-1 py-2 text-sm font-medium transition-colors cursor-pointer
+                  ${form.type === 'CASH'
+                    ? 'bg-sv-accent text-white'
+                    : 'bg-sv-surface text-sv-text-secondary hover:text-sv-text'
+                  }
+                `}
+              >
+                Cash
+              </button>
+              <button
+                type="button"
+                onClick={() => updateField('type', 'REINVESTED')}
+                className={`
+                  flex-1 py-2 text-sm font-medium transition-colors cursor-pointer
+                  ${form.type === 'REINVESTED'
+                    ? 'bg-sv-positive text-white'
+                    : 'bg-sv-surface text-sv-text-secondary hover:text-sv-text'
+                  }
+                `}
+              >
+                Reinvested (DRIP)
+              </button>
+            </div>
+            {form.type === 'REINVESTED' && (
+              <p className="mt-1 text-xs text-sv-text-muted">
+                A BUY transaction will be auto-generated for the reinvested amount.
+              </p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-sv-text-secondary mb-1">Ex-Date</label>
+              <input
+                type="date"
+                value={form.exDate}
+                onChange={(e) => updateField('exDate', e.target.value)}
+                className={INPUT_CLASS_NO_MONO}
+              />
+              {errors.exDate && (
+                <p className="mt-1 text-xs text-sv-negative">{errors.exDate}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-sv-text-secondary mb-1">Pay Date</label>
+              <input
+                type="date"
+                value={form.payDate}
+                onChange={(e) => updateField('payDate', e.target.value)}
+                className={INPUT_CLASS_NO_MONO}
+              />
+              {errors.payDate && (
+                <p className="mt-1 text-xs text-sv-negative">{errors.payDate}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block text-sm font-medium text-sv-text-secondary mb-1">Amount Per Share</label>
+              <input
+                type="number"
+                value={form.amountPerShare}
+                onChange={(e) => updateField('amountPerShare', e.target.value)}
+                min="0.0001"
+                step="any"
+                placeholder="0.0000"
+                className={INPUT_CLASS}
+              />
+              {errors.amountPerShare && (
+                <p className="mt-1 text-xs text-sv-negative">{errors.amountPerShare}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-sv-text-secondary mb-1">Shares Held</label>
+              <input
+                type="number"
+                value={form.sharesAtDate}
+                onChange={(e) => updateField('sharesAtDate', e.target.value)}
+                min="0.0001"
+                step="any"
+                placeholder="0"
+                className={INPUT_CLASS}
+              />
+              {errors.sharesAtDate && (
+                <p className="mt-1 text-xs text-sv-negative">{errors.sharesAtDate}</p>
+              )}
+            </div>
+          </div>
+
+          {totalAmount > 0 && (
+            <div className="px-3 py-2 rounded-md bg-sv-surface border border-sv-border">
+              <div className="flex justify-between items-center">
+                <span className="text-xs text-sv-text-muted">Total Dividend</span>
+                <span className="text-sm font-mono tabular-nums font-semibold text-sv-positive">
+                  ${totalAmount.toFixed(2)}
+                </span>
+              </div>
+            </div>
+          )}
+
+          <div>
+            <label className="block text-sm font-medium text-sv-text-secondary mb-1">
+              Notes <span className="text-sv-text-muted">(optional)</span>
+            </label>
+            <textarea
+              value={form.notes}
+              onChange={(e) => updateField('notes', e.target.value)}
+              rows={2}
+              placeholder="Optional notes..."
+              className={TEXTAREA_CLASS}
+            />
+          </div>
+
+          {submitError && (
+            <div className="px-3 py-2 rounded-md bg-sv-negative/10 border border-sv-negative/20">
+              <p className="text-sm text-sv-negative">{submitError}</p>
+            </div>
+          )}
+        </form>
+
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-sv-border">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-sv-text-secondary hover:text-sv-text bg-sv-surface border border-sv-border rounded-md transition-colors cursor-pointer"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={isSubmitting}
+            onClick={handleSubmit}
+            className="px-4 py-2 text-sm font-medium text-white rounded-md transition-colors cursor-pointer bg-sv-positive hover:bg-sv-positive/80 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? 'Submitting...' : 'Record Dividend'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Dividends/DividendHistoryTable.tsx
+++ b/src/components/Dividends/DividendHistoryTable.tsx
@@ -1,0 +1,188 @@
+import { useState, useMemo } from 'react'
+import { formatCurrency, formatDate, formatShares } from '../../utils/formatters'
+import type { Dividend } from '../../types/index'
+
+type SortField = 'exDate' | 'ticker' | 'amountPerShare' | 'totalAmount' | 'type'
+type SortDirection = 'asc' | 'desc'
+
+interface DividendHistoryTableProps {
+  readonly dividends: ReadonlyArray<Dividend>
+  readonly isLoading: boolean
+  readonly onDelete?: (id: string) => void
+  readonly showTicker?: boolean
+}
+
+function DividendTypeBadge({ type }: { readonly type: Dividend['type'] }) {
+  const isCash = type === 'CASH'
+  return (
+    <span
+      className={`
+        inline-flex items-center px-2 py-0.5 rounded text-xs font-medium
+        ${isCash
+          ? 'bg-sv-accent/10 text-sv-accent'
+          : 'bg-sv-positive/10 text-sv-positive'
+        }
+      `}
+    >
+      {isCash ? 'Cash' : 'DRIP'}
+    </span>
+  )
+}
+
+function SortIcon({ active, direction }: { readonly active: boolean; readonly direction: SortDirection }) {
+  if (!active) {
+    return (
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="opacity-30">
+        <path d="M6 2L9 5H3L6 2Z" fill="currentColor" />
+        <path d="M6 10L3 7H9L6 10Z" fill="currentColor" />
+      </svg>
+    )
+  }
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" className="text-sv-accent">
+      {direction === 'asc' ? (
+        <path d="M6 2L9 5H3L6 2Z" fill="currentColor" />
+      ) : (
+        <path d="M6 10L3 7H9L6 10Z" fill="currentColor" />
+      )}
+    </svg>
+  )
+}
+
+export function DividendHistoryTable({
+  dividends,
+  isLoading,
+  onDelete,
+  showTicker = true
+}: DividendHistoryTableProps) {
+  const [sortField, setSortField] = useState<SortField>('exDate')
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
+
+  const sorted = useMemo(() => {
+    return [...dividends].sort((a, b) => {
+      let cmp = 0
+      switch (sortField) {
+        case 'exDate':
+          cmp = a.exDate.localeCompare(b.exDate)
+          break
+        case 'ticker':
+          cmp = a.ticker.localeCompare(b.ticker)
+          break
+        case 'amountPerShare':
+          cmp = a.amountPerShare - b.amountPerShare
+          break
+        case 'totalAmount':
+          cmp = a.totalAmount - b.totalAmount
+          break
+        case 'type':
+          cmp = a.type.localeCompare(b.type)
+          break
+      }
+      return sortDirection === 'asc' ? cmp : -cmp
+    })
+  }, [dividends, sortField, sortDirection])
+
+  function toggleSort(field: SortField) {
+    if (sortField === field) {
+      setSortDirection((prev) => (prev === 'asc' ? 'desc' : 'asc'))
+    } else {
+      setSortField(field)
+      setSortDirection('desc')
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <div className="bg-sv-surface rounded-lg border border-sv-border p-6">
+        <div className="animate-pulse space-y-3">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <div key={i} className="h-8 bg-sv-elevated rounded" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  if (dividends.length === 0) {
+    return (
+      <div className="bg-sv-surface rounded-lg border border-sv-border p-8 text-center">
+        <p className="text-sv-text-muted text-sm">No dividend payments recorded yet.</p>
+      </div>
+    )
+  }
+
+  function HeaderCell({ field, label }: { readonly field: SortField; readonly label: string }) {
+    return (
+      <th
+        className="px-3 py-2 text-left text-xs font-medium text-sv-text-muted uppercase tracking-wider cursor-pointer hover:text-sv-text transition-colors select-none"
+        onClick={() => toggleSort(field)}
+      >
+        <span className="flex items-center gap-1">
+          {label}
+          <SortIcon active={sortField === field} direction={sortDirection} />
+        </span>
+      </th>
+    )
+  }
+
+  return (
+    <div className="bg-sv-surface rounded-lg border border-sv-border overflow-hidden">
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-sv-border">
+              {showTicker && <HeaderCell field="ticker" label="Ticker" />}
+              <HeaderCell field="exDate" label="Ex-Date" />
+              <th className="px-3 py-2 text-left text-xs font-medium text-sv-text-muted uppercase tracking-wider">Pay Date</th>
+              <HeaderCell field="type" label="Type" />
+              <HeaderCell field="amountPerShare" label="Per Share" />
+              <th className="px-3 py-2 text-right text-xs font-medium text-sv-text-muted uppercase tracking-wider">Shares</th>
+              <HeaderCell field="totalAmount" label="Total" />
+              {onDelete && (
+                <th className="px-3 py-2 text-right text-xs font-medium text-sv-text-muted uppercase tracking-wider w-10" />
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((div) => (
+              <tr
+                key={div.id}
+                className="border-b border-sv-border/50 hover:bg-sv-elevated/50 transition-colors"
+              >
+                {showTicker && (
+                  <td className="px-3 py-2 text-sm font-semibold text-sv-text">{div.ticker}</td>
+                )}
+                <td className="px-3 py-2 text-sm text-sv-text-secondary">{formatDate(div.exDate)}</td>
+                <td className="px-3 py-2 text-sm text-sv-text-secondary">{formatDate(div.payDate)}</td>
+                <td className="px-3 py-2"><DividendTypeBadge type={div.type} /></td>
+                <td className="px-3 py-2 text-sm font-mono tabular-nums text-sv-text text-right">
+                  ${div.amountPerShare.toFixed(4)}
+                </td>
+                <td className="px-3 py-2 text-sm font-mono tabular-nums text-sv-text-secondary text-right">
+                  {formatShares(div.sharesAtDate)}
+                </td>
+                <td className="px-3 py-2 text-sm font-mono tabular-nums font-semibold text-sv-positive text-right">
+                  {formatCurrency(div.totalAmount)}
+                </td>
+                {onDelete && (
+                  <td className="px-3 py-2 text-right">
+                    <button
+                      type="button"
+                      onClick={() => onDelete(div.id)}
+                      className="text-sv-text-muted hover:text-sv-negative transition-colors cursor-pointer"
+                      title="Delete dividend"
+                    >
+                      <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
+                        <path d="M2 4h10M5 4V3a1 1 0 011-1h2a1 1 0 011 1v1m2 0v7a1 1 0 01-1 1H4a1 1 0 01-1-1V4h10z" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+                      </svg>
+                    </button>
+                  </td>
+                )}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Dividends/DividendIncomeChart.tsx
+++ b/src/components/Dividends/DividendIncomeChart.tsx
@@ -1,0 +1,152 @@
+import { useMemo } from 'react'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid
+} from 'recharts'
+import { formatCurrency } from '../../utils/formatters'
+import type { Dividend } from '../../types/index'
+
+interface DividendIncomeChartProps {
+  readonly dividends: ReadonlyArray<Dividend>
+}
+
+interface MonthlyDataPoint {
+  readonly month: string
+  readonly cash: number
+  readonly reinvested: number
+  readonly total: number
+}
+
+function buildMonthlyData(dividends: ReadonlyArray<Dividend>): ReadonlyArray<MonthlyDataPoint> {
+  if (dividends.length === 0) return []
+
+  const monthMap = new Map<string, { cash: number; reinvested: number }>()
+
+  for (const div of dividends) {
+    const monthKey = div.payDate.substring(0, 7)
+    const existing = monthMap.get(monthKey) ?? { cash: 0, reinvested: 0 }
+
+    if (div.type === 'CASH') {
+      monthMap.set(monthKey, { ...existing, cash: existing.cash + div.totalAmount })
+    } else {
+      monthMap.set(monthKey, { ...existing, reinvested: existing.reinvested + div.totalAmount })
+    }
+  }
+
+  const sorted = [...monthMap.entries()].sort((a, b) => a[0].localeCompare(b[0]))
+
+  return sorted.map(([month, data]) => ({
+    month: formatMonthLabel(month),
+    cash: data.cash,
+    reinvested: data.reinvested,
+    total: data.cash + data.reinvested
+  }))
+}
+
+function formatMonthLabel(monthKey: string): string {
+  const [year, month] = monthKey.split('-')
+  const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+  const monthIndex = parseInt(month, 10) - 1
+  return `${months[monthIndex]} ${year.slice(2)}`
+}
+
+interface ChartTooltipProps {
+  readonly active?: boolean
+  readonly payload?: ReadonlyArray<{
+    readonly name: string
+    readonly value: number
+    readonly color: string
+  }>
+  readonly label?: string
+}
+
+function CustomTooltip({ active, payload, label }: ChartTooltipProps) {
+  if (!active || !payload || payload.length === 0) return null
+
+  const total = payload.reduce((sum, entry) => sum + entry.value, 0)
+
+  return (
+    <div className="bg-sv-elevated border border-sv-border rounded-lg px-3 py-2 shadow-lg">
+      <p className="text-xs text-sv-text-muted mb-1">{label}</p>
+      {payload.map((entry) => (
+        <div key={entry.name} className="flex items-center gap-2 text-xs">
+          <span
+            className="w-2 h-2 rounded-full"
+            style={{ backgroundColor: entry.color }}
+          />
+          <span className="text-sv-text-secondary capitalize">{entry.name}</span>
+          <span className="font-mono tabular-nums text-sv-text ml-auto">
+            {formatCurrency(entry.value)}
+          </span>
+        </div>
+      ))}
+      {payload.length > 1 && (
+        <div className="flex items-center gap-2 text-xs mt-1 pt-1 border-t border-sv-border">
+          <span className="text-sv-text-secondary font-medium">Total</span>
+          <span className="font-mono tabular-nums text-sv-positive font-semibold ml-auto">
+            {formatCurrency(total)}
+          </span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export function DividendIncomeChart({ dividends }: DividendIncomeChartProps) {
+  const data = useMemo(() => buildMonthlyData(dividends), [dividends])
+
+  if (data.length === 0) {
+    return (
+      <div className="bg-sv-surface rounded-lg border border-sv-border p-8 text-center">
+        <p className="text-sv-text-muted text-sm">No dividend data to chart.</p>
+      </div>
+    )
+  }
+
+  const hasReinvested = data.some((d) => d.reinvested > 0)
+
+  return (
+    <div className="bg-sv-surface rounded-lg border border-sv-border p-4">
+      <h3 className="text-sm font-semibold text-sv-text mb-3">Monthly Dividend Income</h3>
+      <ResponsiveContainer width="100%" height={280}>
+        <BarChart data={[...data]} margin={{ top: 5, right: 10, left: 10, bottom: 5 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#1A2235" vertical={false} />
+          <XAxis
+            dataKey="month"
+            tick={{ fill: '#6B7280', fontSize: 11 }}
+            tickLine={false}
+            axisLine={{ stroke: '#1A2235' }}
+          />
+          <YAxis
+            tick={{ fill: '#6B7280', fontSize: 11 }}
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={(v: number) => `$${v}`}
+          />
+          <Tooltip content={<CustomTooltip />} cursor={{ fill: 'rgba(59, 130, 246, 0.05)' }} />
+          <Bar
+            dataKey="cash"
+            name="cash"
+            fill="#3B82F6"
+            radius={hasReinvested ? [0, 0, 4, 4] : [4, 4, 4, 4]}
+            stackId="income"
+          />
+          {hasReinvested && (
+            <Bar
+              dataKey="reinvested"
+              name="reinvested"
+              fill="#22C55E"
+              radius={[4, 4, 0, 0]}
+              stackId="income"
+            />
+          )}
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/src/components/Dividends/DividendSummaryCards.tsx
+++ b/src/components/Dividends/DividendSummaryCards.tsx
@@ -1,0 +1,69 @@
+import { formatCurrency, formatPercent } from '../../utils/formatters'
+import type { PortfolioDividendSummary } from '../../types/index'
+
+interface StatCardProps {
+  readonly label: string
+  readonly value: string
+  readonly subValue?: string
+}
+
+function StatCard({ label, value, subValue }: StatCardProps) {
+  return (
+    <div className="rounded-lg bg-sv-surface border border-sv-border p-4">
+      <p className="text-xs text-sv-text-muted uppercase tracking-wider mb-1">
+        {label}
+      </p>
+      <p className="text-xl font-mono tabular-nums font-semibold text-sv-positive">
+        {value}
+      </p>
+      {subValue && (
+        <p className="text-sm font-mono tabular-nums mt-0.5 text-sv-text-secondary">
+          {subValue}
+        </p>
+      )}
+    </div>
+  )
+}
+
+interface DividendSummaryCardsProps {
+  readonly summary: PortfolioDividendSummary | null
+  readonly isLoading: boolean
+}
+
+export function DividendSummaryCards({ summary, isLoading }: DividendSummaryCardsProps) {
+  if (isLoading || !summary) {
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="rounded-lg bg-sv-surface border border-sv-border p-4 animate-pulse h-20"
+          />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+      <StatCard
+        label="All-Time Income"
+        value={formatCurrency(summary.totalIncomeAllTime)}
+        subValue={`${summary.perTicker.reduce((s, t) => s + t.paymentCount, 0)} payments`}
+      />
+      <StatCard
+        label="YTD Income"
+        value={formatCurrency(summary.totalIncomeYtd)}
+      />
+      <StatCard
+        label="Trailing 12M Income"
+        value={formatCurrency(summary.totalIncomeTrailing12m)}
+      />
+      <StatCard
+        label="Annualized Income"
+        value={formatCurrency(summary.totalAnnualizedIncome)}
+        subValue={summary.averageYield > 0 ? `${formatPercent(summary.averageYield)} avg yield` : undefined}
+      />
+    </div>
+  )
+}

--- a/src/components/Dividends/UpcomingDividends.tsx
+++ b/src/components/Dividends/UpcomingDividends.tsx
@@ -1,0 +1,113 @@
+import { useState, useEffect, useMemo } from 'react'
+import { useAppStore } from '../../stores/appStore'
+import { formatCurrency, formatDate } from '../../utils/formatters'
+import type { DividendInfo, Position } from '../../types/index'
+
+interface UpcomingEntry {
+  readonly ticker: string
+  readonly companyName: string
+  readonly exDate: string
+  readonly dividendRate: number
+  readonly yield: number
+}
+
+export function UpcomingDividends() {
+  const positions = useAppStore((s) => s.positions)
+  const [entries, setEntries] = useState<ReadonlyArray<UpcomingEntry>>([])
+  const [isLoading, setIsLoading] = useState(false)
+
+  const openPositions = useMemo(
+    () => positions.filter((p): p is Position => p.status === 'OPEN'),
+    [positions]
+  )
+
+  const openTickerKey = useMemo(
+    () => openPositions.map((p) => p.ticker).sort().join(','),
+    [openPositions]
+  )
+
+  useEffect(() => {
+    if (openPositions.length === 0) return
+
+    let cancelled = false
+    setIsLoading(true)
+
+    const fetchAll = async () => {
+      const results: UpcomingEntry[] = []
+
+      for (const pos of openPositions) {
+        try {
+          const info = await window.electronAPI.getDividendInfo(pos.ticker) as DividendInfo
+          if (info.exDividendDate && info.dividendRate) {
+            const exDate = info.exDividendDate
+            if (exDate >= new Date().toISOString().split('T')[0]) {
+              results.push({
+                ticker: pos.ticker,
+                companyName: pos.companyName,
+                exDate,
+                dividendRate: info.trailingAnnualDividendRate ?? info.dividendRate,
+                yield: info.trailingAnnualDividendYield ?? info.dividendYield ?? 0
+              })
+            }
+          }
+        } catch {
+          // Skip tickers that fail — not all positions pay dividends
+        }
+      }
+
+      if (!cancelled) {
+        const sorted = [...results].sort((a, b) => a.exDate.localeCompare(b.exDate))
+        setEntries(sorted)
+        setIsLoading(false)
+      }
+    }
+
+    fetchAll()
+    return () => { cancelled = true }
+  }, [openTickerKey, openPositions])
+
+  if (isLoading) {
+    return (
+      <div className="bg-sv-surface rounded-lg border border-sv-border p-4">
+        <h3 className="text-sm font-semibold text-sv-text mb-3">Upcoming Ex-Dates</h3>
+        <div className="animate-pulse space-y-2">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="h-8 bg-sv-elevated rounded" />
+          ))}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-sv-surface rounded-lg border border-sv-border p-4">
+      <h3 className="text-sm font-semibold text-sv-text mb-3">Upcoming Ex-Dates</h3>
+      {entries.length === 0 ? (
+        <p className="text-sv-text-muted text-xs">No upcoming ex-dividend dates found for your holdings.</p>
+      ) : (
+        <div className="space-y-2">
+          {entries.map((entry) => (
+            <div
+              key={entry.ticker}
+              className="flex items-center justify-between px-3 py-2 rounded-md bg-sv-elevated/50"
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-semibold text-sv-text">{entry.ticker}</span>
+                <span className="text-xs text-sv-text-muted truncate max-w-[120px]">{entry.companyName}</span>
+              </div>
+              <div className="flex items-center gap-3">
+                <span className="text-xs text-sv-text-secondary">{formatDate(entry.exDate)}</span>
+                <span className="text-xs font-mono tabular-nums text-sv-positive">
+                  {formatCurrency(entry.dividendRate)}/yr
+                </span>
+                <span className="text-xs font-mono tabular-nums text-sv-accent">
+                  {entry.yield.toFixed(2)}%
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/Layout/Shell.tsx
+++ b/src/components/Layout/Shell.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useCallback } from 'react'
 import { useAppStore, type ViewName } from '../../stores/appStore'
+import { useDividendStore } from '../../stores/dividendStore'
 import { Sidebar } from './Sidebar'
 import { TopBar } from './TopBar'
 import { AddTransactionModal } from '../Forms/AddTransactionModal'
@@ -9,6 +10,7 @@ import { CompareView } from '../Views/CompareView'
 import { TransactionsView } from '../Views/TransactionsView'
 import { ClosedPositionsView } from '../Views/ClosedPositionsView'
 import { WatchlistView } from '../Watchlist/WatchlistView'
+import { DividendsView } from '../Views/DividendsView'
 
 function renderView(activeView: ViewName) {
   switch (activeView) {
@@ -24,6 +26,8 @@ function renderView(activeView: ViewName) {
       return <ClosedPositionsView />
     case 'watchlist':
       return <WatchlistView />
+    case 'dividends':
+      return <DividendsView />
     default:
       return <DashboardView />
   }
@@ -37,6 +41,7 @@ export function Shell() {
   const modalOpen = useAppStore((state) => state.modalOpen)
   const setModalOpen = useAppStore((state) => state.setModalOpen)
   const selectedTicker = useAppStore((state) => state.selectedTicker)
+  const fetchDividendSummary = useDividendStore((state) => state.fetchDividendSummary)
 
   const handleCloseModal = useCallback(() => {
     setModalOpen(false)
@@ -82,9 +87,14 @@ export function Shell() {
       } catch {
         // Store actions throw with details; positions will remain empty
       }
+      try {
+        await fetchDividendSummary()
+      } catch {
+        // Dividend summary is best-effort
+      }
     }
     loadInitialData()
-  }, [fetchPositions])
+  }, [fetchPositions, fetchDividendSummary])
 
   useEffect(() => {
     const tickers = positions.map((p) => p.ticker)

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -93,11 +93,21 @@ function CollapseIcon({ collapsed }: { readonly collapsed: boolean }) {
   )
 }
 
+function DividendsIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <line x1="10" y1="2" x2="10" y2="18" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+      <path d="M14 6H8.5a2.5 2.5 0 000 5h3a2.5 2.5 0 010 5H6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
 const NAV_ITEMS: ReadonlyArray<NavItem> = [
   { id: 'dashboard', label: 'Dashboard', icon: <DashboardIcon /> },
   { id: 'position-detail', label: 'Positions', icon: <PositionsIcon /> },
   { id: 'compare', label: 'Compare', icon: <CompareIcon /> },
   { id: 'transactions', label: 'Transactions', icon: <TransactionsIcon /> },
+  { id: 'dividends', label: 'Dividends', icon: <DividendsIcon /> },
   { id: 'closed-positions', label: 'Closed Trades', icon: <ClosedTradesIcon /> },
   { id: 'watchlist', label: 'Watchlist', icon: <WatchlistIcon /> }
 ]

--- a/src/components/Portfolio/PortfolioSummary.tsx
+++ b/src/components/Portfolio/PortfolioSummary.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import { usePortfolioStats } from '../../hooks/usePortfolioStats'
+import { useDividendStore } from '../../stores/dividendStore'
 import { computePortfolioSummary } from '../../utils/calculations'
 import type { Position, Quote } from '../../types/index'
 import {
@@ -46,17 +47,19 @@ interface PortfolioSummaryProps {
 
 export function PortfolioSummary({ filteredPositions, quotes }: PortfolioSummaryProps = {}) {
   const { summary: allSummary, isLoading } = usePortfolioStats()
+  const dividendSummary = useDividendStore((s) => s.summary)
 
   const summary = useMemo(() => {
     if (!filteredPositions || !quotes) return allSummary
     const quotesArray = Object.values(quotes)
-    return computePortfolioSummary(filteredPositions, quotesArray)
-  }, [filteredPositions, quotes, allSummary])
+    const totalDividendIncome = dividendSummary?.totalIncomeAllTime ?? 0
+    return computePortfolioSummary(filteredPositions, quotesArray, totalDividendIncome)
+  }, [filteredPositions, quotes, allSummary, dividendSummary])
 
   if (isLoading) {
     return (
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-        {Array.from({ length: 5 }).map((_, i) => (
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
+        {Array.from({ length: 6 }).map((_, i) => (
           <div
             key={i}
             className="rounded-lg bg-sv-surface border border-sv-border p-4 animate-pulse h-20"
@@ -67,7 +70,7 @@ export function PortfolioSummary({ filteredPositions, quotes }: PortfolioSummary
   }
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-4">
       <StatCard
         label="Total Portfolio Value"
         value={formatCurrency(summary.totalValue)}
@@ -89,6 +92,11 @@ export function PortfolioSummary({ filteredPositions, quotes }: PortfolioSummary
         label="Realized Gain/Loss"
         value={formatSignedCurrency(summary.totalRealizedGain)}
         colorClass={getGainColorClass(summary.totalRealizedGain)}
+      />
+      <StatCard
+        label="Dividend Income"
+        value={formatSignedCurrency(summary.totalDividendIncome)}
+        colorClass={getGainColorClass(summary.totalDividendIncome)}
       />
       <StatCard
         label="Total Return"

--- a/src/components/Positions/PositionDetail.tsx
+++ b/src/components/Positions/PositionDetail.tsx
@@ -2,10 +2,13 @@ import { useState, useEffect, useCallback } from 'react'
 import { formatDistanceToNow, parseISO } from 'date-fns'
 import { useAppStore } from '../../stores/appStore'
 import { useMarketData } from '../../hooks/useMarketData'
+import { useDividends, useDividendInfo } from '../../hooks/useDividends'
 import { PriceChart } from '../Charts/PriceChart'
 import { TransactionHistory } from './TransactionHistory'
 import { TaxLotTable } from '../TaxLots/TaxLotTable'
 import { CostBasisMethodSelector } from '../TaxLots/CostBasisMethodSelector'
+import { DividendHistoryTable } from '../Dividends/DividendHistoryTable'
+import { AddDividendModal } from '../Dividends/AddDividendModal'
 import {
   formatCurrency,
   formatSignedCurrency,
@@ -172,6 +175,9 @@ function PositionDetailInner({
   const taxLotsLoading = useAppStore((s) => s.taxLotsLoading)
   const fetchTaxLots = useAppStore((s) => s.fetchTaxLots)
   const setCostBasisMethod = useAppStore((s) => s.setCostBasisMethod)
+  const { dividends, isLoading: dividendsLoading } = useDividends(ticker)
+  const dividendInfo = useDividendInfo(ticker)
+  const [dividendModalOpen, setDividendModalOpen] = useState(false)
 
   useEffect(() => {
     let cancelled = false
@@ -200,6 +206,8 @@ function PositionDetailInner({
     await setCostBasisMethod(_ticker, method)
   }, [setCostBasisMethod])
 
+  const totalDividendIncome = dividends.reduce((sum, d) => sum + d.totalAmount, 0)
+
   return (
     <div className="flex flex-col h-full gap-4 p-4">
       <DetailHeader
@@ -211,7 +219,7 @@ function PositionDetailInner({
       />
 
       <div className="flex flex-1 gap-4 min-h-0">
-        <div className="w-[60%] min-h-0 flex flex-col gap-4">
+        <div className="w-[60%] min-h-0 flex flex-col gap-4 overflow-auto">
           <PriceChart
             ticker={ticker}
             transactions={[...transactions]}
@@ -219,6 +227,26 @@ function PositionDetailInner({
             color={position.color}
           />
           <TaxLotTable lots={taxLots} quote={quote} loading={taxLotsLoading} />
+
+          {(dividends.length > 0 || dividendsLoading) && (
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <h3 className="text-sm font-semibold text-sv-text">Dividend History</h3>
+                <button
+                  type="button"
+                  onClick={() => setDividendModalOpen(true)}
+                  className="text-xs text-sv-accent hover:text-sv-accent/80 transition-colors cursor-pointer"
+                >
+                  + Record Dividend
+                </button>
+              </div>
+              <DividendHistoryTable
+                dividends={dividends}
+                isLoading={dividendsLoading}
+                showTicker={false}
+              />
+            </div>
+          )}
         </div>
 
         <div className="w-[40%] flex flex-col gap-4 min-h-0 overflow-auto">
@@ -227,7 +255,22 @@ function PositionDetailInner({
             currentMethod={position.costBasisMethod}
             onMethodChange={handleMethodChange}
           />
-          <StatsPanel position={position} quote={quote} transactions={transactions} />
+          <StatsPanel
+            position={position}
+            quote={quote}
+            transactions={transactions}
+            totalDividendIncome={totalDividendIncome}
+            dividendInfo={dividendInfo}
+          />
+          {dividends.length === 0 && !dividendsLoading && (
+            <button
+              type="button"
+              onClick={() => setDividendModalOpen(true)}
+              className="w-full py-2 text-sm font-medium text-sv-accent border border-sv-border border-dashed rounded-md hover:bg-sv-elevated/50 transition-colors cursor-pointer"
+            >
+              + Record Dividend Payment
+            </button>
+          )}
           {txLoading ? (
             <div className="text-sv-text-muted text-sm text-center py-4">Loading transactions...</div>
           ) : (
@@ -235,6 +278,12 @@ function PositionDetailInner({
           )}
         </div>
       </div>
+
+      <AddDividendModal
+        isOpen={dividendModalOpen}
+        onClose={() => setDividendModalOpen(false)}
+        prefillTicker={ticker}
+      />
     </div>
   )
 }
@@ -282,9 +331,11 @@ interface StatsPanelProps {
   readonly position: Position
   readonly quote: Quote | null
   readonly transactions: ReadonlyArray<Transaction>
+  readonly totalDividendIncome?: number
+  readonly dividendInfo?: import('../../types/index').DividendInfo | null
 }
 
-function StatsPanel({ position, quote, transactions }: StatsPanelProps) {
+function StatsPanel({ position, quote, transactions, totalDividendIncome = 0, dividendInfo }: StatsPanelProps) {
   const currentPrice = quote?.price ?? 0
   const marketValue = currentPrice * position.totalShares
   const unrealizedGain = marketValue - position.costBasis * position.totalShares
@@ -294,7 +345,7 @@ function StatsPanel({ position, quote, transactions }: StatsPanelProps) {
       : 0
   const dayChange = (quote?.dayChange ?? 0) * position.totalShares
   const dayChangePct = quote?.dayChangePercent ?? 0
-  const totalReturn = unrealizedGain + position.totalRealized
+  const totalReturn = unrealizedGain + position.totalRealized + totalDividendIncome
   const holdingPeriod = computeHoldingPeriod(transactions)
 
   const stats: ReadonlyArray<{ readonly label: string; readonly value: string; readonly colorClass: string }> = [
@@ -307,6 +358,13 @@ function StatsPanel({ position, quote, transactions }: StatsPanelProps) {
     { label: 'Day Change', value: formatSignedCurrency(dayChange), colorClass: getValueColorClass(dayChange) },
     { label: 'Day Change %', value: formatPercent(dayChangePct), colorClass: getValueColorClass(dayChangePct) },
     { label: 'Realized G/L', value: formatSignedCurrency(position.totalRealized), colorClass: getValueColorClass(position.totalRealized) },
+    { label: 'Dividend Income', value: formatSignedCurrency(totalDividendIncome), colorClass: getValueColorClass(totalDividendIncome) },
+    ...(dividendInfo?.dividendYield != null ? [
+      { label: 'Dividend Yield', value: `${dividendInfo.dividendYield.toFixed(2)}%`, colorClass: 'text-sv-accent' as const }
+    ] : []),
+    ...(dividendInfo?.trailingAnnualDividendRate != null ? [
+      { label: 'Annual Div Rate', value: formatCurrency(dividendInfo.trailingAnnualDividendRate), colorClass: 'text-sv-text' as const }
+    ] : []),
     { label: 'Total Return', value: formatSignedCurrency(totalReturn), colorClass: getValueColorClass(totalReturn) },
     { label: 'Holding Period', value: holdingPeriod, colorClass: 'text-sv-text' }
   ]

--- a/src/components/Views/DividendsView.tsx
+++ b/src/components/Views/DividendsView.tsx
@@ -1,0 +1,140 @@
+import { useState, useCallback, useRef, useEffect } from 'react'
+import { useDividends, useDividendSummary } from '../../hooks/useDividends'
+import { useDividendStore } from '../../stores/dividendStore'
+import { DividendSummaryCards } from '../Dividends/DividendSummaryCards'
+import { DividendHistoryTable } from '../Dividends/DividendHistoryTable'
+import { DividendIncomeChart } from '../Dividends/DividendIncomeChart'
+import { UpcomingDividends } from '../Dividends/UpcomingDividends'
+import { AddDividendModal } from '../Dividends/AddDividendModal'
+
+function PlusIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+      <path d="M8 3v10M3 8h10" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function EmptyState({ onAdd }: { readonly onAdd: () => void }) {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[60vh] gap-6">
+      <div className="text-center">
+        <div className="mx-auto mb-4 w-16 h-16 rounded-full bg-sv-positive/10 flex items-center justify-center">
+          <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#22C55E" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="12" y1="1" x2="12" y2="23" />
+            <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+          </svg>
+        </div>
+        <h2 className="text-xl font-semibold text-sv-text mb-2">
+          No dividends recorded yet
+        </h2>
+        <p className="text-sm text-sv-text-muted max-w-sm">
+          Record your first dividend payment to start tracking income, yields, and reinvestments across your portfolio.
+        </p>
+      </div>
+      <button
+        type="button"
+        className="px-6 py-3 rounded-lg bg-sv-positive text-white font-semibold text-sm hover:brightness-110 transition-all cursor-pointer"
+        onClick={onAdd}
+      >
+        Record Your First Dividend
+      </button>
+    </div>
+  )
+}
+
+export function DividendsView() {
+  const { dividends, isLoading: dividendsLoading } = useDividends()
+  const { summary, isLoading: summaryLoading } = useDividendSummary()
+  const deleteDividend = useDividendStore((s) => s.deleteDividend)
+  const [modalOpen, setModalOpen] = useState(false)
+  const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null)
+  const deleteTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (deleteTimerRef.current) {
+        clearTimeout(deleteTimerRef.current)
+      }
+    }
+  }, [])
+
+  const handleDelete = useCallback(async (id: string) => {
+    if (deleteConfirmId === id) {
+      if (deleteTimerRef.current) {
+        clearTimeout(deleteTimerRef.current)
+        deleteTimerRef.current = null
+      }
+      try {
+        await deleteDividend(id)
+      } catch {
+        // Error thrown by store
+      }
+      setDeleteConfirmId(null)
+    } else {
+      setDeleteConfirmId(id)
+      if (deleteTimerRef.current) {
+        clearTimeout(deleteTimerRef.current)
+      }
+      deleteTimerRef.current = setTimeout(() => {
+        setDeleteConfirmId(null)
+        deleteTimerRef.current = null
+      }, 3000)
+    }
+  }, [deleteConfirmId, deleteDividend])
+
+  const hasDividends = dividends.length > 0
+
+  if (!hasDividends && !dividendsLoading) {
+    return (
+      <>
+        <EmptyState onAdd={() => setModalOpen(true)} />
+        <AddDividendModal
+          isOpen={modalOpen}
+          onClose={() => setModalOpen(false)}
+        />
+      </>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-lg font-semibold text-sv-text">Dividend Income</h1>
+        <button
+          type="button"
+          onClick={() => setModalOpen(true)}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-sv-positive text-white text-sm font-medium hover:brightness-110 transition-all cursor-pointer"
+        >
+          <PlusIcon />
+          Record Dividend
+        </button>
+      </div>
+
+      <DividendSummaryCards summary={summary} isLoading={summaryLoading} />
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <div className="lg:col-span-2">
+          <DividendIncomeChart dividends={dividends} />
+        </div>
+        <div>
+          <UpcomingDividends />
+        </div>
+      </div>
+
+      <div>
+        <h2 className="text-sm font-semibold text-sv-text mb-2">Payment History</h2>
+        <DividendHistoryTable
+          dividends={dividends}
+          isLoading={dividendsLoading}
+          onDelete={handleDelete}
+        />
+      </div>
+
+      <AddDividendModal
+        isOpen={modalOpen}
+        onClose={() => setModalOpen(false)}
+      />
+    </div>
+  )
+}

--- a/src/hooks/useDividends.ts
+++ b/src/hooks/useDividends.ts
@@ -1,0 +1,51 @@
+import { useEffect, useMemo } from 'react'
+import { useDividendStore } from '../stores/dividendStore'
+
+export function useDividends(ticker?: string) {
+  const dividends = useDividendStore((s) => s.dividends)
+  const dividendsLoading = useDividendStore((s) => s.dividendsLoading)
+  const fetchDividends = useDividendStore((s) => s.fetchDividends)
+
+  useEffect(() => {
+    const filters = ticker ? { ticker } : undefined
+    fetchDividends(filters).catch(() => {})
+  }, [ticker, fetchDividends])
+
+  const filtered = useMemo(() => {
+    if (!ticker) return dividends
+    return dividends.filter((d) => d.ticker === ticker.toUpperCase())
+  }, [dividends, ticker])
+
+  return {
+    dividends: filtered,
+    isLoading: dividendsLoading
+  } as const
+}
+
+export function useDividendSummary() {
+  const summary = useDividendStore((s) => s.summary)
+  const summaryLoading = useDividendStore((s) => s.summaryLoading)
+  const fetchDividendSummary = useDividendStore((s) => s.fetchDividendSummary)
+
+  useEffect(() => {
+    fetchDividendSummary().catch(() => {})
+  }, [fetchDividendSummary])
+
+  return {
+    summary,
+    isLoading: summaryLoading
+  } as const
+}
+
+export function useDividendInfo(ticker: string) {
+  const info = useDividendStore((s) => s.dividendInfo[ticker] ?? null)
+  const fetchDividendInfo = useDividendStore((s) => s.fetchDividendInfo)
+
+  useEffect(() => {
+    if (ticker) {
+      fetchDividendInfo(ticker).catch(() => {})
+    }
+  }, [ticker, fetchDividendInfo])
+
+  return info
+}

--- a/src/hooks/usePortfolioStats.ts
+++ b/src/hooks/usePortfolioStats.ts
@@ -1,16 +1,19 @@
 import { useMemo } from 'react'
 import { useAppStore } from '../stores/appStore'
+import { useDividendStore } from '../stores/dividendStore'
 import { computePortfolioSummary } from '../utils/calculations'
 
 export function usePortfolioStats() {
   const positions = useAppStore((state) => state.positions)
   const quotes = useAppStore((state) => state.quotes)
   const positionsLoading = useAppStore((state) => state.positionsLoading)
+  const dividendSummary = useDividendStore((state) => state.summary)
 
   const summary = useMemo(() => {
     const quotesArray = Object.values(quotes)
-    return computePortfolioSummary(positions, quotesArray)
-  }, [positions, quotes])
+    const totalDividendIncome = dividendSummary?.totalIncomeAllTime ?? 0
+    return computePortfolioSummary(positions, quotesArray, totalDividendIncome)
+  }, [positions, quotes, dividendSummary])
 
   return {
     summary,

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import type { Position, Quote, NewTransaction, TaxLot, CostBasisMethod, TaxReportSummary } from '../types/index'
 
-export type ViewName = 'dashboard' | 'position-detail' | 'compare' | 'transactions' | 'closed-positions' | 'watchlist'
+export type ViewName = 'dashboard' | 'position-detail' | 'compare' | 'transactions' | 'closed-positions' | 'watchlist' | 'dividends'
 export type GainStatus = 'all' | 'winners' | 'losers'
 
 export interface FilterState {

--- a/src/stores/dividendStore.ts
+++ b/src/stores/dividendStore.ts
@@ -1,0 +1,109 @@
+import { create } from 'zustand'
+import type {
+  Dividend,
+  NewDividend,
+  DividendFilters,
+  PortfolioDividendSummary,
+  DividendInfo
+} from '../types/index'
+
+interface DividendState {
+  readonly dividends: ReadonlyArray<Dividend>
+  readonly dividendsLoading: boolean
+  readonly summary: PortfolioDividendSummary | null
+  readonly summaryLoading: boolean
+  readonly dividendInfo: Readonly<Record<string, DividendInfo>>
+}
+
+interface DividendActions {
+  readonly fetchDividends: (filters?: DividendFilters) => Promise<void>
+  readonly addDividend: (input: NewDividend) => Promise<Dividend>
+  readonly updateDividend: (id: string, updates: Partial<NewDividend>) => Promise<Dividend>
+  readonly deleteDividend: (id: string) => Promise<void>
+  readonly fetchDividendSummary: () => Promise<void>
+  readonly fetchDividendInfo: (ticker: string) => Promise<void>
+}
+
+type DividendStore = DividendState & DividendActions
+
+export const useDividendStore = create<DividendStore>()((set, get) => ({
+  dividends: [],
+  dividendsLoading: false,
+  summary: null,
+  summaryLoading: false,
+  dividendInfo: {},
+
+  fetchDividends: async (filters?: DividendFilters) => {
+    set({ dividendsLoading: true })
+    try {
+      const dividends = await window.electronAPI.getDividends(filters) as Dividend[]
+      set({ dividends, dividendsLoading: false })
+    } catch (error) {
+      set({ dividendsLoading: false })
+      throw new Error(
+        `Failed to fetch dividends: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  },
+
+  addDividend: async (input: NewDividend) => {
+    try {
+      const dividend = await window.electronAPI.addDividend(input) as Dividend
+      await get().fetchDividends()
+      await get().fetchDividendSummary()
+      return dividend
+    } catch (error) {
+      throw new Error(
+        `Failed to add dividend: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  },
+
+  updateDividend: async (id: string, updates: Partial<NewDividend>) => {
+    try {
+      const dividend = await window.electronAPI.updateDividend(id, updates) as Dividend
+      await get().fetchDividends()
+      await get().fetchDividendSummary()
+      return dividend
+    } catch (error) {
+      throw new Error(
+        `Failed to update dividend: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  },
+
+  deleteDividend: async (id: string) => {
+    try {
+      await window.electronAPI.deleteDividend(id)
+      await get().fetchDividends()
+      await get().fetchDividendSummary()
+    } catch (error) {
+      throw new Error(
+        `Failed to delete dividend: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  },
+
+  fetchDividendSummary: async () => {
+    set({ summaryLoading: true })
+    try {
+      const summary = await window.electronAPI.getDividendSummary() as PortfolioDividendSummary
+      set({ summary, summaryLoading: false })
+    } catch (error) {
+      set({ summaryLoading: false })
+      throw new Error(
+        `Failed to fetch dividend summary: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  },
+
+  fetchDividendInfo: async (ticker: string) => {
+    try {
+      const info = await window.electronAPI.getDividendInfo(ticker) as DividendInfo
+      const existing = get().dividendInfo
+      set({ dividendInfo: { ...existing, [ticker]: info } })
+    } catch {
+      // Dividend info is best-effort; not all tickers pay dividends
+    }
+  }
+}))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,9 +76,78 @@ export interface ElectronAPI {
   generateTaxReport: (year?: number) => Promise<TaxReportSummary>
   exportTaxReportCsv: (year?: number) => Promise<string>
   addTransactionWithLots: (tx: NewTransaction, lotSelections?: ReadonlyArray<{ lotId: string; shares: number }>) => Promise<Transaction>
+  getDividends: (filters?: DividendFilters) => Promise<Dividend[]>
+  addDividend: (dividend: NewDividend) => Promise<Dividend>
+  updateDividend: (id: string, updates: Partial<NewDividend>) => Promise<Dividend>
+  deleteDividend: (id: string) => Promise<void>
+  getDividendSummary: () => Promise<PortfolioDividendSummary>
+  getDividendHistory: (ticker: string, from?: string) => Promise<DividendHistoryEntry[]>
+  getDividendInfo: (ticker: string) => Promise<DividendInfo>
 }
 
 export type TransactionType = 'BUY' | 'SELL'
+export type DividendType = 'CASH' | 'REINVESTED'
+
+export interface Dividend {
+  readonly id: string
+  readonly ticker: string
+  readonly exDate: string
+  readonly payDate: string
+  readonly amountPerShare: number
+  readonly totalAmount: number
+  readonly sharesAtDate: number
+  readonly type: DividendType
+  readonly linkedTransactionId: string | null
+  readonly notes: string | null
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+export interface NewDividend {
+  readonly ticker: string
+  readonly exDate: string
+  readonly payDate: string
+  readonly amountPerShare: number
+  readonly sharesAtDate: number
+  readonly type: DividendType
+  readonly notes?: string
+}
+
+export interface DividendSummary {
+  readonly ticker: string
+  readonly companyName: string
+  readonly totalIncome: number
+  readonly ytdIncome: number
+  readonly trailing12mIncome: number
+  readonly paymentCount: number
+  readonly lastPayDate: string | null
+  readonly annualizedIncome: number
+  readonly dividendYield: number
+}
+
+export interface PortfolioDividendSummary {
+  readonly totalIncomeAllTime: number
+  readonly totalIncomeYtd: number
+  readonly totalIncomeTrailing12m: number
+  readonly totalAnnualizedIncome: number
+  readonly averageYield: number
+  readonly perTicker: ReadonlyArray<DividendSummary>
+}
+
+export interface DividendInfo {
+  readonly dividendRate: number | null
+  readonly dividendYield: number | null
+  readonly exDividendDate: string | null
+  readonly fiveYearAvgDividendYield: number | null
+  readonly payoutRatio: number | null
+  readonly trailingAnnualDividendRate: number | null
+  readonly trailingAnnualDividendYield: number | null
+}
+
+export interface DividendHistoryEntry {
+  readonly date: string
+  readonly amount: number
+}
 
 export interface Transaction {
   readonly id: string
@@ -158,6 +227,7 @@ export interface PortfolioSummary {
   readonly totalUnrealizedGain: number
   readonly totalUnrealizedGainPercent: number
   readonly totalRealizedGain: number
+  readonly totalDividendIncome: number
   readonly totalReturn: number
   readonly totalReturnPercent: number
   readonly positionCount: number
@@ -184,6 +254,13 @@ export interface NewWatchlistItem {
   readonly ticker: string
   readonly companyName: string
   readonly notes?: string
+}
+
+export interface DividendFilters {
+  readonly ticker?: string
+  readonly fromDate?: string
+  readonly toDate?: string
+  readonly type?: DividendType
 }
 
 declare global {

--- a/src/utils/calculations.ts
+++ b/src/utils/calculations.ts
@@ -95,7 +95,8 @@ export function computePosition(
 
 export function computePortfolioSummary(
   positions: ReadonlyArray<Position>,
-  quotes: ReadonlyArray<Quote>
+  quotes: ReadonlyArray<Quote>,
+  totalDividendIncome: number = 0
 ): PortfolioSummary {
   const quoteMap = new Map(quotes.map((q) => [q.ticker, q]))
 
@@ -132,7 +133,7 @@ export function computePortfolioSummary(
     totalValue - totalDayChange > 0
       ? (totalDayChange / (totalValue - totalDayChange)) * 100
       : 0
-  const totalReturn = totalUnrealizedGain + totalRealizedGain
+  const totalReturn = totalUnrealizedGain + totalRealizedGain + totalDividendIncome
   const totalInvestedAll = positions.reduce((sum, p) => sum + p.totalInvested, 0)
   const totalReturnPercent = totalInvestedAll > 0 ? (totalReturn / totalInvestedAll) * 100 : 0
 
@@ -144,6 +145,7 @@ export function computePortfolioSummary(
     totalUnrealizedGain,
     totalUnrealizedGainPercent,
     totalRealizedGain,
+    totalDividendIncome,
     totalReturn,
     totalReturnPercent,
     positionCount


### PR DESCRIPTION
## Summary

Implements Phase 4 of the dividend tracking epic (#5):

- **Dividend data model and recording** (closes #15): New `dividends` table with full CRUD, atomic DRIP auto-generation of BUY transactions, and Yahoo Finance dividend history/yield fetching
- **Income dashboard and per-position yield** (closes #16): Dedicated Dividends view with income summary cards (all-time, YTD, trailing 12M, annualized), monthly income bar chart, upcoming ex-dates calendar, sortable payment history table, and per-position dividend stats in PositionDetail

### Key features
- Record dividends as **CASH** or **REINVESTED** (DRIP automatically creates linked BUY transactions within a DB transaction)
- Dividend income included in **total return** calculations across dashboard and position detail
- Per-position **dividend yield** and **annual rate** from Yahoo Finance `summaryDetail`
- **Upcoming ex-dates** panel fetched from Yahoo Finance for all open positions
- Full IPC handler input validation and database transaction safety for all dividend operations

### Files changed
- **New files (9)**: `electron/db/dividends.ts`, `src/stores/dividendStore.ts`, `src/hooks/useDividends.ts`, `src/components/Dividends/*` (5 components), `src/components/Views/DividendsView.tsx`
- **Modified files (12)**: database schema, IPC handlers, preload bridge, market data, types, calculations, navigation, dashboard, position detail

## Test plan

- [ ] Record a CASH dividend for an existing position — verify it appears in history table and income cards
- [ ] Record a REINVESTED (DRIP) dividend — verify a BUY transaction is auto-created and shares increase
- [ ] Delete a DRIP dividend — verify the linked BUY transaction is also removed
- [ ] Check dashboard Total Return card includes dividend income
- [ ] Check PositionDetail shows dividend yield, annual rate, and dividend history
- [ ] Navigate to Dividends view — verify summary cards, income chart, and upcoming ex-dates
- [ ] Verify monthly income chart renders correctly with stacked CASH/DRIP bars
- [ ] Test with no dividends recorded — verify empty state with CTA button
- [ ] Verify TypeScript compiles cleanly with `npm run typecheck`