### PR TITLE
feat: multi-portfolio support

### DIFF
--- a/electron/db/benchmarks.ts
+++ b/electron/db/benchmarks.ts
@@ -22,18 +22,34 @@ interface DividendRow {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function getAllEquityTransactions(): ReadonlyArray<Transaction> {
+function getAllEquityTransactions(portfolioId?: number): ReadonlyArray<Transaction> {
   const db = getDatabase()
-  return db.prepare(
-    "SELECT * FROM transactions WHERE asset_type = 'EQUITY' ORDER BY date ASC, created_at ASC"
-  ).all() as Transaction[]
+
+  let query = "SELECT * FROM transactions WHERE asset_type = 'EQUITY'"
+  const params: unknown[] = []
+
+  if (portfolioId !== undefined) {
+    query += ' AND portfolio_id = ?'
+    params.push(portfolioId)
+  }
+
+  query += ' ORDER BY date ASC, created_at ASC'
+  return db.prepare(query).all(...params) as Transaction[]
 }
 
-function getAllDividends(from: string, to: string): ReadonlyArray<DividendRow> {
+function getAllDividends(from: string, to: string, portfolioId?: number): ReadonlyArray<DividendRow> {
   const db = getDatabase()
-  return db.prepare(
-    'SELECT ticker, pay_date, total_amount FROM dividends WHERE pay_date >= ? AND pay_date <= ? ORDER BY pay_date ASC'
-  ).all(from, to) as DividendRow[]
+
+  let query = 'SELECT ticker, pay_date, total_amount FROM dividends WHERE pay_date >= ? AND pay_date <= ?'
+  const params: unknown[] = [from, to]
+
+  if (portfolioId !== undefined) {
+    query += ' AND portfolio_id = ?'
+    params.push(portfolioId)
+  }
+
+  query += ' ORDER BY pay_date ASC'
+  return db.prepare(query).all(...params) as DividendRow[]
 }
 
 function generateDateRange(from: string, to: string): ReadonlyArray<string> {
@@ -204,8 +220,8 @@ function buildCashFlows(
  *
  * Returns daily cumulative return series rebased to 0% at the start.
  */
-export function computePortfolioTWR(from: string, to: string): ReadonlyArray<TWRDataPoint> {
-  const allTransactions = getAllEquityTransactions()
+export function computePortfolioTWR(from: string, to: string, portfolioId?: number): ReadonlyArray<TWRDataPoint> {
+  const allTransactions = getAllEquityTransactions(portfolioId)
 
   if (allTransactions.length === 0) {
     return []
@@ -225,7 +241,7 @@ export function computePortfolioTWR(from: string, to: string): ReadonlyArray<TWR
     (tx) => tx.date.slice(0, 10) >= effectiveFrom && tx.date.slice(0, 10) <= to
   )
 
-  const dividends = getAllDividends(effectiveFrom, to)
+  const dividends = getAllDividends(effectiveFrom, to, portfolioId)
   const dates = generateDateRange(effectiveFrom, to)
 
   if (dates.length === 0) {

--- a/electron/db/database.ts
+++ b/electron/db/database.ts
@@ -122,11 +122,74 @@ function runMigrations(database: Database.Database): void {
   addColumnIfNotExists(database, 'transactions', 'expiration_date', 'TEXT')
   addColumnIfNotExists(database, 'transactions', 'contract_multiplier', 'INTEGER')
   addColumnIfNotExists(database, 'transactions', 'option_action', 'TEXT')
+
+  // Multi-portfolio support
+  database.exec(`
+    CREATE TABLE IF NOT EXISTS portfolios (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      name TEXT NOT NULL UNIQUE,
+      description TEXT,
+      is_default INTEGER NOT NULL DEFAULT 0,
+      default_cost_basis_method TEXT NOT NULL DEFAULT 'AVGCOST',
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+    );
+  `)
+
+  migratePortfolios(database)
 }
 
-const ALLOWED_TABLES = new Set(['ticker_metadata', 'transactions', 'tax_lots', 'lot_assignments', 'price_cache', 'watchlist', 'dividends'])
+const ALLOWED_TABLES = new Set(['ticker_metadata', 'transactions', 'tax_lots', 'lot_assignments', 'price_cache', 'watchlist', 'dividends', 'portfolios'])
 const IDENTIFIER_PATTERN = /^[a-z_]+$/
 const DEFINITION_PATTERN = /^[A-Z ]+(?:\([^)]+\))?(?:\s+(?:NOT NULL|DEFAULT '[^']*'|DEFAULT \d+))*$/
+
+function migratePortfolios(database: Database.Database): void {
+  // Ensure a default portfolio exists
+  const defaultPortfolio = database.prepare(
+    'SELECT id FROM portfolios WHERE is_default = 1'
+  ).get() as { id: number } | undefined
+
+  if (!defaultPortfolio) {
+    database.prepare(
+      "INSERT INTO portfolios (name, description, is_default, default_cost_basis_method) VALUES ('Default', 'Default portfolio', 1, 'AVGCOST')"
+    ).run()
+  }
+
+  // Add portfolio_id column to transactions if not present
+  addColumnIfNotExists(database, 'transactions', 'portfolio_id', 'INTEGER')
+
+  // Add portfolio_id column to dividends if not present
+  addColumnIfNotExists(database, 'dividends', 'portfolio_id', 'INTEGER')
+
+  // Backfill existing transactions and dividends with the default portfolio
+  const dp = database.prepare(
+    'SELECT id FROM portfolios WHERE is_default = 1'
+  ).get() as { id: number }
+
+  const unassignedTx = database.prepare(
+    'SELECT COUNT(*) as count FROM transactions WHERE portfolio_id IS NULL'
+  ).get() as { count: number }
+
+  if (unassignedTx.count > 0) {
+    database.prepare(
+      'UPDATE transactions SET portfolio_id = ? WHERE portfolio_id IS NULL'
+    ).run(dp.id)
+  }
+
+  const unassignedDiv = database.prepare(
+    'SELECT COUNT(*) as count FROM dividends WHERE portfolio_id IS NULL'
+  ).get() as { count: number }
+
+  if (unassignedDiv.count > 0) {
+    database.prepare(
+      'UPDATE dividends SET portfolio_id = ? WHERE portfolio_id IS NULL'
+    ).run(dp.id)
+  }
+
+  // Create index for portfolio_id on transactions
+  database.exec('CREATE INDEX IF NOT EXISTS idx_transactions_portfolio ON transactions(portfolio_id)')
+  database.exec('CREATE INDEX IF NOT EXISTS idx_dividends_portfolio ON dividends(portfolio_id)')
+}
 
 function addColumnIfNotExists(database: Database.Database, table: string, column: string, definition: string): void {
   if (!ALLOWED_TABLES.has(table)) {

--- a/electron/db/dividends.ts
+++ b/electron/db/dividends.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto'
 import { getDatabase } from './database'
 import { addTransaction } from './positions'
+import { getDefaultPortfolioId } from './portfolios'
 import type {
   Dividend,
   NewDividend,
@@ -19,6 +20,7 @@ interface DividendRow {
   readonly shares_at_date: number
   readonly type: string
   readonly linked_transaction_id: string | null
+  readonly portfolio_id: number | null
   readonly notes: string | null
   readonly created_at: string
   readonly updated_at: string
@@ -35,6 +37,7 @@ function rowToDividend(row: DividendRow): Dividend {
     sharesAtDate: row.shares_at_date,
     type: row.type as Dividend['type'],
     linkedTransactionId: row.linked_transaction_id,
+    portfolioId: row.portfolio_id,
     notes: row.notes,
     createdAt: row.created_at,
     updatedAt: row.updated_at
@@ -48,6 +51,7 @@ export function addDividend(input: NewDividend): Dividend {
   const ticker = input.ticker.toUpperCase()
   const totalAmount = input.amountPerShare * input.sharesAtDate
   const notes = input.notes ?? null
+  const portfolioId = input.portfolioId ?? getDefaultPortfolioId()
 
   let linkedTransactionId: string | null = null
 
@@ -65,18 +69,19 @@ export function addDividend(input: NewDividend): Dividend {
         price: dripPrice,
         date: input.payDate,
         fees: 0,
-        notes: `DRIP reinvestment from ${input.exDate} dividend`
+        notes: `DRIP reinvestment from ${input.exDate} dividend`,
+        portfolioId
       })
       linkedTransactionId = dripTransaction.id
     }
 
     db.prepare(`
-      INSERT INTO dividends (id, ticker, ex_date, pay_date, amount_per_share, total_amount, shares_at_date, type, linked_transaction_id, notes, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO dividends (id, ticker, ex_date, pay_date, amount_per_share, total_amount, shares_at_date, type, linked_transaction_id, portfolio_id, notes, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       id, ticker, input.exDate, input.payDate,
       input.amountPerShare, totalAmount, input.sharesAtDate,
-      input.type, linkedTransactionId, notes, now, now
+      input.type, linkedTransactionId, portfolioId, notes, now, now
     )
 
     return {
@@ -89,6 +94,7 @@ export function addDividend(input: NewDividend): Dividend {
       sharesAtDate: input.sharesAtDate,
       type: input.type,
       linkedTransactionId,
+      portfolioId,
       notes,
       createdAt: now,
       updatedAt: now
@@ -140,6 +146,10 @@ export function getDividends(filters?: DividendFilters): ReadonlyArray<Dividend>
   if (filters?.toDate) {
     conditions.push('ex_date <= ?')
     params.push(filters.toDate)
+  }
+  if (filters?.portfolioId !== undefined) {
+    conditions.push('portfolio_id = ?')
+    params.push(filters.portfolioId)
   }
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
@@ -224,6 +234,7 @@ export function updateDividend(id: string, updates: Partial<NewDividend>): Divid
       sharesAtDate: merged.sharesAtDate,
       type: merged.type as Dividend['type'],
       linkedTransactionId,
+      portfolioId: existing.portfolio_id,
       notes: merged.notes,
       createdAt: existing.created_at,
       updatedAt: now
@@ -247,7 +258,7 @@ export function deleteDividend(id: string): void {
   })()
 }
 
-export function getDividendSummary(): PortfolioDividendSummary {
+export function getDividendSummary(portfolioId?: number): PortfolioDividendSummary {
   const db = getDatabase()
   const now = new Date()
   const yearStart = `${now.getFullYear()}-01-01`
@@ -255,9 +266,16 @@ export function getDividendSummary(): PortfolioDividendSummary {
   trailing12m.setFullYear(trailing12m.getFullYear() - 1)
   const trailing12mStr = trailing12m.toISOString().split('T')[0]
 
-  const allDividends = db.prepare(
-    'SELECT * FROM dividends ORDER BY ex_date DESC'
-  ).all() as DividendRow[]
+  let query = 'SELECT * FROM dividends'
+  const params: unknown[] = []
+
+  if (portfolioId !== undefined) {
+    query += ' WHERE portfolio_id = ?'
+    params.push(portfolioId)
+  }
+
+  query += ' ORDER BY ex_date DESC'
+  const allDividends = db.prepare(query).all(...params) as DividendRow[]
 
   if (allDividends.length === 0) {
     return {
@@ -362,10 +380,17 @@ function computeAnnualizedIncome(rows: ReadonlyArray<DividendRow>): number {
   return (totalIncome / daySpan) * 365
 }
 
-export function getTotalDividendIncome(): number {
+export function getTotalDividendIncome(portfolioId?: number): number {
   const db = getDatabase()
-  const result = db.prepare(
-    'SELECT COALESCE(SUM(total_amount), 0) as total FROM dividends'
-  ).get() as { total: number }
+
+  let query = 'SELECT COALESCE(SUM(total_amount), 0) as total FROM dividends'
+  const params: unknown[] = []
+
+  if (portfolioId !== undefined) {
+    query += ' WHERE portfolio_id = ?'
+    params.push(portfolioId)
+  }
+
+  const result = db.prepare(query).get(...params) as { total: number }
   return result.total
 }

--- a/electron/db/options.ts
+++ b/electron/db/options.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto'
 import { differenceInCalendarDays, parseISO } from 'date-fns'
 import { getDatabase } from './database'
+import { getDefaultPortfolioId } from './portfolios'
 import { buildOccSymbol } from '../../src/utils/occSymbol'
 import type {
   OptionAction,
@@ -38,23 +39,24 @@ export function addOptionTransaction(tx: NewOptionTransaction): OptionTransactio
   const fees = tx.fees ?? 0
   const notes = tx.notes ?? null
   const multiplier = 100
+  const portfolioId = tx.portfolioId ?? getDefaultPortfolioId()
 
   if (CLOSING_ACTIONS.has(tx.optionAction) && tx.optionAction !== 'EXPIRE') {
-    validateOptionClose(ticker, tx.optionType, tx.strikePrice, tx.expirationDate, tx.contracts, tx.optionAction)
+    validateOptionClose(ticker, tx.optionType, tx.strikePrice, tx.expirationDate, tx.contracts, tx.optionAction, portfolioId)
   }
 
   const stmt = db.prepare(`
     INSERT INTO transactions (
       id, ticker, type, shares, price, date, fees, notes,
       asset_type, option_type, strike_price, expiration_date, contract_multiplier, option_action,
-      created_at, updated_at
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'OPTION', ?, ?, ?, ?, ?, ?, ?)
+      portfolio_id, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'OPTION', ?, ?, ?, ?, ?, ?, ?, ?)
   `)
 
   stmt.run(
     id, ticker, type, tx.contracts, tx.price, tx.date, fees, notes,
     tx.optionType, tx.strikePrice, tx.expirationDate, multiplier, tx.optionAction,
-    now, now
+    portfolioId, now, now
   )
 
   return {
@@ -105,6 +107,10 @@ export function getOptionTransactions(
     conditions.push('option_type = ?')
     params.push(filters.optionType)
   }
+  if (filters?.portfolioId !== undefined) {
+    conditions.push('portfolio_id = ?')
+    params.push(filters.portfolioId)
+  }
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
   const rows = db.prepare(
@@ -129,6 +135,10 @@ export function getOptionPositions(
   if (filters?.optionType) {
     query += ' AND option_type = ?'
     params.push(filters.optionType)
+  }
+  if (filters?.portfolioId !== undefined) {
+    query += ' AND portfolio_id = ?'
+    params.push(filters.portfolioId)
   }
 
   query += ' ORDER BY ticker, expiration_date, strike_price'
@@ -294,15 +304,24 @@ function validateOptionClose(
   strikePrice: number,
   expirationDate: string,
   contractsToClose: number,
-  action: OptionAction
+  action: OptionAction,
+  portfolioId?: number
 ): void {
   const db = getDatabase()
 
-  const transactions = db.prepare(`
+  let query = `
     SELECT option_action, shares FROM transactions
-    WHERE asset_type = 'OPTION' AND ticker = ? AND option_type = ? AND strike_price = ? AND expiration_date = ?
-    ORDER BY date ASC, created_at ASC
-  `).all(ticker, optionType, strikePrice, expirationDate) as ReadonlyArray<{
+    WHERE asset_type = 'OPTION' AND ticker = ? AND option_type = ? AND strike_price = ? AND expiration_date = ?`
+  const params: unknown[] = [ticker, optionType, strikePrice, expirationDate]
+
+  if (portfolioId !== undefined) {
+    query += ' AND portfolio_id = ?'
+    params.push(portfolioId)
+  }
+
+  query += ' ORDER BY date ASC, created_at ASC'
+
+  const transactions = db.prepare(query).all(...params) as ReadonlyArray<{
     option_action: string
     shares: number
   }>

--- a/electron/db/portfolios.ts
+++ b/electron/db/portfolios.ts
@@ -1,0 +1,201 @@
+import { getDatabase } from './database'
+import type { Portfolio, NewPortfolio, UpdatePortfolio, CostBasisMethod } from '../../src/types/index'
+
+interface PortfolioRow {
+  readonly id: number
+  readonly name: string
+  readonly description: string | null
+  readonly is_default: number
+  readonly default_cost_basis_method: string
+  readonly created_at: string
+  readonly updated_at: string
+}
+
+function rowToPortfolio(row: PortfolioRow): Portfolio {
+  return {
+    id: row.id,
+    name: row.name,
+    description: row.description,
+    isDefault: row.is_default === 1,
+    defaultCostBasisMethod: row.default_cost_basis_method as CostBasisMethod,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at
+  }
+}
+
+export function listPortfolios(): ReadonlyArray<Portfolio> {
+  const db = getDatabase()
+  const rows = db.prepare(
+    'SELECT * FROM portfolios ORDER BY is_default DESC, name ASC'
+  ).all() as PortfolioRow[]
+  return rows.map(rowToPortfolio)
+}
+
+export function getPortfolio(id: number): Portfolio {
+  const db = getDatabase()
+  const row = db.prepare(
+    'SELECT * FROM portfolios WHERE id = ?'
+  ).get(id) as PortfolioRow | undefined
+
+  if (!row) {
+    throw new Error(`Portfolio ${id} not found`)
+  }
+
+  return rowToPortfolio(row)
+}
+
+export function getDefaultPortfolioId(): number {
+  const db = getDatabase()
+  const row = db.prepare(
+    'SELECT id FROM portfolios WHERE is_default = 1'
+  ).get() as { id: number } | undefined
+
+  if (!row) {
+    throw new Error('No default portfolio found')
+  }
+
+  return row.id
+}
+
+export function createPortfolio(input: NewPortfolio): Portfolio {
+  const db = getDatabase()
+  const name = input.name.trim()
+
+  if (name.length === 0 || name.length > 100) {
+    throw new Error('Portfolio name must be between 1 and 100 characters')
+  }
+
+  const existing = db.prepare(
+    'SELECT id FROM portfolios WHERE name = ?'
+  ).get(name) as { id: number } | undefined
+
+  if (existing) {
+    throw new Error(`Portfolio "${name}" already exists`)
+  }
+
+  const description = input.description?.trim() ?? null
+  const costBasisMethod = input.defaultCostBasisMethod ?? 'AVGCOST'
+  const validMethods: ReadonlyArray<CostBasisMethod> = ['FIFO', 'LIFO', 'AVGCOST', 'SPECIFIC']
+
+  if (!validMethods.includes(costBasisMethod)) {
+    throw new Error(`Invalid cost basis method: ${costBasisMethod}`)
+  }
+
+  const now = new Date().toISOString()
+
+  const result = db.prepare(`
+    INSERT INTO portfolios (name, description, is_default, default_cost_basis_method, created_at, updated_at)
+    VALUES (?, ?, 0, ?, ?, ?)
+  `).run(name, description, costBasisMethod, now, now)
+
+  return {
+    id: result.lastInsertRowid as number,
+    name,
+    description,
+    isDefault: false,
+    defaultCostBasisMethod: costBasisMethod,
+    createdAt: now,
+    updatedAt: now
+  }
+}
+
+export function updatePortfolio(id: number, updates: UpdatePortfolio): Portfolio {
+  const db = getDatabase()
+
+  const existing = db.prepare(
+    'SELECT * FROM portfolios WHERE id = ?'
+  ).get(id) as PortfolioRow | undefined
+
+  if (!existing) {
+    throw new Error(`Portfolio ${id} not found`)
+  }
+
+  const name = updates.name !== undefined ? updates.name.trim() : existing.name
+  if (name.length === 0 || name.length > 100) {
+    throw new Error('Portfolio name must be between 1 and 100 characters')
+  }
+
+  if (updates.name !== undefined && updates.name.trim() !== existing.name) {
+    const duplicate = db.prepare(
+      'SELECT id FROM portfolios WHERE name = ? AND id != ?'
+    ).get(name, id) as { id: number } | undefined
+
+    if (duplicate) {
+      throw new Error(`Portfolio "${name}" already exists`)
+    }
+  }
+
+  const description = updates.description !== undefined ? (updates.description?.trim() ?? null) : existing.description
+  const costBasisMethod = updates.defaultCostBasisMethod ?? existing.default_cost_basis_method
+
+  const validMethods: ReadonlyArray<string> = ['FIFO', 'LIFO', 'AVGCOST', 'SPECIFIC']
+  if (!validMethods.includes(costBasisMethod)) {
+    throw new Error(`Invalid cost basis method: ${costBasisMethod}`)
+  }
+
+  const now = new Date().toISOString()
+
+  db.prepare(`
+    UPDATE portfolios SET name = ?, description = ?, default_cost_basis_method = ?, updated_at = ?
+    WHERE id = ?
+  `).run(name, description, costBasisMethod, now, id)
+
+  return {
+    id,
+    name,
+    description,
+    isDefault: existing.is_default === 1,
+    defaultCostBasisMethod: costBasisMethod as CostBasisMethod,
+    createdAt: existing.created_at,
+    updatedAt: now
+  }
+}
+
+export function deletePortfolio(id: number): void {
+  const db = getDatabase()
+
+  const existing = db.prepare(
+    'SELECT * FROM portfolios WHERE id = ?'
+  ).get(id) as PortfolioRow | undefined
+
+  if (!existing) {
+    throw new Error(`Portfolio ${id} not found`)
+  }
+
+  if (existing.is_default === 1) {
+    throw new Error('Cannot delete the default portfolio')
+  }
+
+  db.transaction(() => {
+    // Delete lot assignments for transactions in this portfolio
+    db.prepare(`
+      DELETE FROM lot_assignments WHERE sell_transaction_id IN (
+        SELECT id FROM transactions WHERE portfolio_id = ?
+      )
+    `).run(id)
+
+    db.prepare(`
+      DELETE FROM lot_assignments WHERE tax_lot_id IN (
+        SELECT tl.id FROM tax_lots tl
+        JOIN transactions t ON tl.transaction_id = t.id
+        WHERE t.portfolio_id = ?
+      )
+    `).run(id)
+
+    // Delete tax lots for transactions in this portfolio
+    db.prepare(`
+      DELETE FROM tax_lots WHERE transaction_id IN (
+        SELECT id FROM transactions WHERE portfolio_id = ?
+      )
+    `).run(id)
+
+    // Delete dividends in this portfolio
+    db.prepare('DELETE FROM dividends WHERE portfolio_id = ?').run(id)
+
+    // Delete transactions in this portfolio
+    db.prepare('DELETE FROM transactions WHERE portfolio_id = ?').run(id)
+
+    // Delete the portfolio
+    db.prepare('DELETE FROM portfolios WHERE id = ?').run(id)
+  })()
+}

--- a/electron/db/positions.ts
+++ b/electron/db/positions.ts
@@ -8,6 +8,23 @@ import {
   removeAssignmentsForTransaction,
   recomputeLotsForTicker
 } from './taxLots'
+import { getDefaultPortfolioId } from './portfolios'
+
+function rowToTransaction(row: Record<string, unknown>): Transaction {
+  return {
+    id: row.id as string,
+    ticker: row.ticker as string,
+    type: row.type as Transaction['type'],
+    shares: row.shares as number,
+    price: row.price as number,
+    date: row.date as string,
+    fees: row.fees as number,
+    notes: row.notes as string | null,
+    portfolioId: row.portfolio_id as number | null,
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string
+  }
+}
 
 export function addTransaction(
   tx: NewTransaction,
@@ -19,17 +36,18 @@ export function addTransaction(
   const fees = tx.fees ?? 0
   const notes = tx.notes ?? null
   const ticker = tx.ticker.toUpperCase()
+  const portfolioId = tx.portfolioId ?? getDefaultPortfolioId()
 
   if (tx.type === 'SELL') {
-    validateSell(ticker, tx.shares, tx.date)
+    validateSell(ticker, tx.shares, tx.date, undefined, portfolioId)
   }
 
   const stmt = db.prepare(`
-    INSERT INTO transactions (id, ticker, type, shares, price, date, fees, notes, created_at, updated_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO transactions (id, ticker, type, shares, price, date, fees, notes, portfolio_id, created_at, updated_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `)
 
-  stmt.run(id, ticker, tx.type, tx.shares, tx.price, tx.date, fees, notes, now, now)
+  stmt.run(id, ticker, tx.type, tx.shares, tx.price, tx.date, fees, notes, portfolioId, now, now)
 
   const transaction: Transaction = {
     id,
@@ -40,6 +58,7 @@ export function addTransaction(
     date: tx.date,
     fees,
     notes,
+    portfolioId,
     created_at: now,
     updated_at: now
   }
@@ -57,10 +76,11 @@ export function addTransaction(
 export function updateTransaction(id: string, updates: Partial<NewTransaction>): Transaction {
   const db = getDatabase()
 
-  const existing = db.prepare('SELECT * FROM transactions WHERE id = ?').get(id) as Transaction | undefined
-  if (!existing) {
+  const existingRow = db.prepare('SELECT * FROM transactions WHERE id = ?').get(id) as Record<string, unknown> | undefined
+  if (!existingRow) {
     throw new Error(`Transaction ${id} not found`)
   }
+  const existing = rowToTransaction(existingRow)
 
   const merged = {
     ticker: updates.ticker?.toUpperCase() ?? existing.ticker,
@@ -72,8 +92,10 @@ export function updateTransaction(id: string, updates: Partial<NewTransaction>):
     notes: updates.notes !== undefined ? (updates.notes ?? null) : existing.notes
   }
 
+  const portfolioId = existing.portfolioId ?? undefined
+
   if (merged.type === 'SELL') {
-    validateSell(merged.ticker, merged.shares, merged.date, id)
+    validateSell(merged.ticker, merged.shares, merged.date, id, portfolioId)
   }
 
   const now = new Date().toISOString()
@@ -85,9 +107,9 @@ export function updateTransaction(id: string, updates: Partial<NewTransaction>):
       WHERE id = ?
     `).run(merged.ticker, merged.type, merged.shares, merged.price, merged.date, merged.fees, merged.notes, now, id)
 
-    recomputeLotsForTicker(merged.ticker)
+    recomputeLotsForTicker(merged.ticker, portfolioId)
     if (existing.ticker !== merged.ticker) {
-      recomputeLotsForTicker(existing.ticker)
+      recomputeLotsForTicker(existing.ticker, portfolioId)
     }
   })()
 
@@ -100,6 +122,7 @@ export function updateTransaction(id: string, updates: Partial<NewTransaction>):
     date: merged.date,
     fees: merged.fees,
     notes: merged.notes,
+    portfolioId: existing.portfolioId,
     created_at: existing.created_at,
     updated_at: now
   }
@@ -108,15 +131,17 @@ export function updateTransaction(id: string, updates: Partial<NewTransaction>):
 export function deleteTransaction(id: string): void {
   const db = getDatabase()
 
-  const existing = db.prepare('SELECT * FROM transactions WHERE id = ?').get(id) as Transaction | undefined
-  if (!existing) {
+  const existingRow = db.prepare('SELECT * FROM transactions WHERE id = ?').get(id) as Record<string, unknown> | undefined
+  if (!existingRow) {
     throw new Error(`Transaction ${id} not found`)
   }
+  const existing = rowToTransaction(existingRow)
+  const portfolioId = existing.portfolioId ?? undefined
 
   db.transaction(() => {
     removeAssignmentsForTransaction(id)
     db.prepare('DELETE FROM transactions WHERE id = ?').run(id)
-    recomputeLotsForTicker(existing.ticker)
+    recomputeLotsForTicker(existing.ticker, portfolioId)
   })()
 }
 
@@ -141,25 +166,59 @@ export function getTransactions(filters?: TransactionFilters): ReadonlyArray<Tra
     conditions.push('date <= ?')
     params.push(filters.toDate)
   }
+  if (filters?.portfolioId !== undefined) {
+    conditions.push('portfolio_id = ?')
+    params.push(filters.portfolioId)
+  }
 
   const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
-  const rows = db.prepare(`SELECT * FROM transactions ${where} ORDER BY date ASC, created_at ASC`).all(...params)
+  const rows = db.prepare(`SELECT * FROM transactions ${where} ORDER BY date ASC, created_at ASC`).all(...params) as Array<Record<string, unknown>>
 
-  return rows as Transaction[]
+  return rows.map((row) => ({
+    id: row.id as string,
+    ticker: row.ticker as string,
+    type: row.type as Transaction['type'],
+    shares: row.shares as number,
+    price: row.price as number,
+    date: row.date as string,
+    fees: row.fees as number,
+    notes: row.notes as string | null,
+    portfolioId: row.portfolio_id as number | null,
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string
+  }))
 }
 
-export function getPositions(): ReadonlyArray<Position> {
+export function getPositions(portfolioId?: number): ReadonlyArray<Position> {
   const db = getDatabase()
-  const tickers = db.prepare("SELECT DISTINCT ticker FROM transactions WHERE asset_type = 'EQUITY' ORDER BY ticker").all() as Array<{ ticker: string }>
 
-  return tickers.map((row) => computePosition(row.ticker))
+  let query = "SELECT DISTINCT ticker FROM transactions WHERE asset_type = 'EQUITY'"
+  const params: unknown[] = []
+
+  if (portfolioId !== undefined) {
+    query += ' AND portfolio_id = ?'
+    params.push(portfolioId)
+  }
+
+  query += ' ORDER BY ticker'
+  const tickers = db.prepare(query).all(...params) as Array<{ ticker: string }>
+
+  return tickers.map((row) => computePosition(row.ticker, portfolioId))
 }
 
-function computePosition(ticker: string): Position {
+function computePosition(ticker: string, portfolioId?: number): Position {
   const db = getDatabase()
-  const transactions = db.prepare(
-    "SELECT * FROM transactions WHERE ticker = ? AND asset_type = 'EQUITY' ORDER BY date ASC, created_at ASC"
-  ).all(ticker) as Transaction[]
+
+  let txQuery = "SELECT * FROM transactions WHERE ticker = ? AND asset_type = 'EQUITY'"
+  const txParams: unknown[] = [ticker]
+
+  if (portfolioId !== undefined) {
+    txQuery += ' AND portfolio_id = ?'
+    txParams.push(portfolioId)
+  }
+
+  txQuery += ' ORDER BY date ASC, created_at ASC'
+  const transactions = db.prepare(txQuery).all(...txParams) as Transaction[]
 
   let firstBuyDate: string | null = null
   let lastSellDate: string | null = null
@@ -180,9 +239,17 @@ function computePosition(ticker: string): Position {
     .filter((tx) => tx.type === 'BUY')
     .reduce((sum, tx) => sum + tx.shares * tx.price, 0)
 
-  const remainingLots = db.prepare(
-    'SELECT remaining_shares, cost_per_share FROM tax_lots WHERE ticker = ? AND remaining_shares > 0'
-  ).all(ticker) as ReadonlyArray<{ remaining_shares: number; cost_per_share: number }>
+  let lotsQuery = 'SELECT tl.remaining_shares, tl.cost_per_share FROM tax_lots tl'
+  const lotsParams: unknown[] = [ticker]
+
+  if (portfolioId !== undefined) {
+    lotsQuery += ' JOIN transactions t ON tl.transaction_id = t.id WHERE tl.ticker = ? AND tl.remaining_shares > 0 AND t.portfolio_id = ?'
+    lotsParams.push(portfolioId)
+  } else {
+    lotsQuery += ' WHERE tl.ticker = ? AND tl.remaining_shares > 0'
+  }
+
+  const remainingLots = db.prepare(lotsQuery).all(...lotsParams) as ReadonlyArray<{ remaining_shares: number; cost_per_share: number }>
 
   let totalShares = 0
   let totalRemainingCost = 0
@@ -192,11 +259,22 @@ function computePosition(ticker: string): Position {
   }
   const costBasis = totalShares > 0 ? totalRemainingCost / totalShares : 0
 
-  const assignments = db.prepare(`
+  let assignQuery = `
     SELECT la.realized_gain, la.is_short_term FROM lot_assignments la
-    JOIN tax_lots tl ON la.tax_lot_id = tl.id
-    WHERE tl.ticker = ?
-  `).all(ticker) as ReadonlyArray<{ realized_gain: number; is_short_term: number }>
+    JOIN tax_lots tl ON la.tax_lot_id = tl.id`
+  const assignParams: unknown[] = [ticker]
+
+  if (portfolioId !== undefined) {
+    assignQuery += `
+    JOIN transactions t ON tl.transaction_id = t.id
+    WHERE tl.ticker = ? AND t.portfolio_id = ?`
+    assignParams.push(portfolioId)
+  } else {
+    assignQuery += `
+    WHERE tl.ticker = ?`
+  }
+
+  const assignments = db.prepare(assignQuery).all(...assignParams) as ReadonlyArray<{ realized_gain: number; is_short_term: number }>
 
   let totalRealized = 0
   let shortTermGain = 0
@@ -234,7 +312,7 @@ function computePosition(ticker: string): Position {
   }
 }
 
-function validateSell(ticker: string, sharesToSell: number, sellDate: string, excludeId?: string): void {
+function validateSell(ticker: string, sharesToSell: number, sellDate: string, excludeId?: string, portfolioId?: number): void {
   const db = getDatabase()
 
   let query = `
@@ -246,6 +324,11 @@ function validateSell(ticker: string, sharesToSell: number, sellDate: string, ex
   if (excludeId) {
     query += ' AND id != ?'
     params.push(excludeId)
+  }
+
+  if (portfolioId !== undefined) {
+    query += ' AND portfolio_id = ?'
+    params.push(portfolioId)
   }
 
   query += ' ORDER BY date ASC, created_at ASC'

--- a/electron/db/taxLots.ts
+++ b/electron/db/taxLots.ts
@@ -431,23 +431,53 @@ export function setCostBasisMethod(ticker: string, method: CostBasisMethod): voi
   }
 }
 
-export function recomputeLotsForTicker(ticker: string): void {
+export function recomputeLotsForTicker(ticker: string, portfolioId?: number): void {
   const db = getDatabase()
   const method = getCostBasisMethod(ticker)
 
   db.transaction(() => {
-    db.prepare('DELETE FROM lot_assignments WHERE tax_lot_id IN (SELECT id FROM tax_lots WHERE ticker = ?)').run(ticker)
-    db.prepare('DELETE FROM tax_lots WHERE ticker = ?').run(ticker)
+    if (portfolioId !== undefined) {
+      // Portfolio-scoped: only recompute lots for transactions in this portfolio
+      db.prepare(`
+        DELETE FROM lot_assignments WHERE tax_lot_id IN (
+          SELECT tl.id FROM tax_lots tl
+          JOIN transactions t ON tl.transaction_id = t.id
+          WHERE tl.ticker = ? AND t.portfolio_id = ?
+        )
+      `).run(ticker, portfolioId)
 
-    const transactions = db.prepare(
-      'SELECT * FROM transactions WHERE ticker = ? ORDER BY date ASC, created_at ASC'
-    ).all(ticker) as Transaction[]
+      db.prepare(`
+        DELETE FROM tax_lots WHERE ticker = ? AND transaction_id IN (
+          SELECT id FROM transactions WHERE ticker = ? AND portfolio_id = ?
+        )
+      `).run(ticker, ticker, portfolioId)
 
-    for (const tx of transactions) {
-      if (tx.type === 'BUY') {
-        createTaxLot(tx)
-      } else {
-        assignLotsForSell(tx, method)
+      const transactions = db.prepare(
+        "SELECT * FROM transactions WHERE ticker = ? AND portfolio_id = ? AND asset_type = 'EQUITY' ORDER BY date ASC, created_at ASC"
+      ).all(ticker, portfolioId) as Transaction[]
+
+      for (const tx of transactions) {
+        if (tx.type === 'BUY') {
+          createTaxLot(tx)
+        } else {
+          assignLotsForSell(tx, method)
+        }
+      }
+    } else {
+      // Global: recompute all lots for this ticker across all portfolios
+      db.prepare('DELETE FROM lot_assignments WHERE tax_lot_id IN (SELECT id FROM tax_lots WHERE ticker = ?)').run(ticker)
+      db.prepare('DELETE FROM tax_lots WHERE ticker = ?').run(ticker)
+
+      const transactions = db.prepare(
+        "SELECT * FROM transactions WHERE ticker = ? AND asset_type = 'EQUITY' ORDER BY date ASC, created_at ASC"
+      ).all(ticker) as Transaction[]
+
+      for (const tx of transactions) {
+        if (tx.type === 'BUY') {
+          createTaxLot(tx)
+        } else {
+          assignLotsForSell(tx, method)
+        }
       }
     }
   })()

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -41,6 +41,14 @@ import {
   computeBenchmarkTWR,
   computeBenchmarkStats
 } from './db/benchmarks'
+import {
+  listPortfolios,
+  getPortfolio,
+  createPortfolio,
+  updatePortfolio,
+  deletePortfolio
+} from './db/portfolios'
+import type { NewPortfolio, UpdatePortfolio } from '../src/types/index'
 
 function createWindow(): BrowserWindow {
   const win = new BrowserWindow({
@@ -118,12 +126,22 @@ function registerIpcHandlers(): void {
     deleteTransaction(id)
   })
 
-  ipcMain.handle('db:getTransactions', (_event, filters?: TransactionFilters) => {
-    return getTransactions(filters)
+  ipcMain.handle('db:getTransactions', (_event, filters?: unknown) => {
+    if (filters !== undefined) {
+      if (typeof filters !== 'object' || filters === null) throw new Error('Invalid filters')
+      const f = filters as Record<string, unknown>
+      if (f.ticker !== undefined && (typeof f.ticker !== 'string' || f.ticker.length === 0)) throw new Error('Invalid ticker filter')
+      if (f.type !== undefined && f.type !== 'BUY' && f.type !== 'SELL') throw new Error('Invalid type filter')
+      if (f.fromDate !== undefined && typeof f.fromDate !== 'string') throw new Error('Invalid fromDate filter')
+      if (f.toDate !== undefined && typeof f.toDate !== 'string') throw new Error('Invalid toDate filter')
+      if (f.portfolioId !== undefined && typeof f.portfolioId !== 'number') throw new Error('Invalid portfolio ID filter')
+    }
+    return getTransactions(filters as TransactionFilters | undefined)
   })
 
-  ipcMain.handle('db:getPositions', () => {
-    return getPositions()
+  ipcMain.handle('db:getPositions', (_event, portfolioId?: unknown) => {
+    if (portfolioId !== undefined && typeof portfolioId !== 'number') throw new Error('Invalid portfolio ID')
+    return getPositions(portfolioId as number | undefined)
   })
 
   ipcMain.handle('db:getPortfolioSummary', () => {
@@ -332,8 +350,9 @@ function registerIpcHandlers(): void {
     deleteDividend(id)
   })
 
-  ipcMain.handle('db:getDividendSummary', () => {
-    return getDividendSummary()
+  ipcMain.handle('db:getDividendSummary', (_event, portfolioId?: unknown) => {
+    if (portfolioId !== undefined && typeof portfolioId !== 'number') throw new Error('Invalid portfolio ID')
+    return getDividendSummary(portfolioId as number | undefined)
   })
 
   ipcMain.handle('market:getDividendHistory', async (_event, ticker: string, from?: string) => {
@@ -359,9 +378,10 @@ function registerIpcHandlers(): void {
     if (typeof ticker !== 'string' || ticker.length === 0 || ticker.length > 10) throw new Error('Invalid ticker')
   }
 
-  ipcMain.handle('db:getPortfolioTWR', async (_event, from: unknown, to: unknown) => {
+  ipcMain.handle('db:getPortfolioTWR', async (_event, from: unknown, to: unknown, portfolioId?: unknown) => {
     validateDateRange(from, to)
-    return computePortfolioTWR(from, to as string)
+    if (portfolioId !== undefined && typeof portfolioId !== 'number') throw new Error('Invalid portfolio ID')
+    return computePortfolioTWR(from, to as string, portfolioId as number | undefined)
   })
 
   ipcMain.handle('db:getBenchmarkTWR', async (_event, ticker: unknown, from: unknown, to: unknown) => {
@@ -370,18 +390,20 @@ function registerIpcHandlers(): void {
     return computeBenchmarkTWR(ticker, from, to as string)
   })
 
-  ipcMain.handle('db:getBenchmarkStats', async (_event, benchmarkTicker: unknown, from: unknown, to: unknown) => {
+  ipcMain.handle('db:getBenchmarkStats', async (_event, benchmarkTicker: unknown, from: unknown, to: unknown, portfolioId?: unknown) => {
     validateBenchmarkTicker(benchmarkTicker)
     validateDateRange(from, to)
-    const portfolioTWR = computePortfolioTWR(from, to as string)
+    if (portfolioId !== undefined && typeof portfolioId !== 'number') throw new Error('Invalid portfolio ID')
+    const portfolioTWR = computePortfolioTWR(from, to as string, portfolioId as number | undefined)
     const benchmarkTWR = computeBenchmarkTWR(benchmarkTicker, from, to as string)
     return computeBenchmarkStats(portfolioTWR, benchmarkTWR, from, to as string)
   })
 
-  ipcMain.handle('db:getBenchmarkData', async (_event, benchmarkTicker: unknown, from: unknown, to: unknown) => {
+  ipcMain.handle('db:getBenchmarkData', async (_event, benchmarkTicker: unknown, from: unknown, to: unknown, portfolioId?: unknown) => {
     validateBenchmarkTicker(benchmarkTicker)
     validateDateRange(from, to)
-    const portfolioTWR = computePortfolioTWR(from, to as string)
+    if (portfolioId !== undefined && typeof portfolioId !== 'number') throw new Error('Invalid portfolio ID')
+    const portfolioTWR = computePortfolioTWR(from, to as string, portfolioId as number | undefined)
     const benchmarkTWR = computeBenchmarkTWR(benchmarkTicker, from, to as string)
     const stats = computeBenchmarkStats(portfolioTWR, benchmarkTWR, from, to as string)
     return { portfolioTWR, benchmarkTWR, stats }
@@ -424,6 +446,58 @@ function registerIpcHandlers(): void {
     if (typeof ticker !== 'string' || ticker.length === 0) throw new Error('Invalid ticker')
     if (expirationDate !== undefined && typeof expirationDate !== 'string') throw new Error('Invalid expiration date')
     return getOptionsChain(ticker, expirationDate)
+  })
+
+  // Portfolio CRUD handlers
+  ipcMain.handle('db:listPortfolios', () => {
+    return listPortfolios()
+  })
+
+  ipcMain.handle('db:getPortfolio', (_event, id: unknown) => {
+    if (typeof id !== 'number' || !Number.isInteger(id) || id <= 0) throw new Error('Invalid portfolio ID')
+    return getPortfolio(id)
+  })
+
+  ipcMain.handle('db:createPortfolio', (_event, input: unknown) => {
+    if (!input || typeof input !== 'object') throw new Error('Invalid input')
+    const { name, description, defaultCostBasisMethod } = input as Record<string, unknown>
+    if (typeof name !== 'string' || name.trim().length === 0 || name.length > 100) {
+      throw new Error('Invalid portfolio name')
+    }
+    if (description !== undefined && description !== null && typeof description !== 'string') {
+      throw new Error('Invalid description')
+    }
+    if (defaultCostBasisMethod !== undefined) {
+      const validMethods = ['FIFO', 'LIFO', 'AVGCOST', 'SPECIFIC']
+      if (typeof defaultCostBasisMethod !== 'string' || !validMethods.includes(defaultCostBasisMethod)) {
+        throw new Error('Invalid cost basis method')
+      }
+    }
+    return createPortfolio(input as NewPortfolio)
+  })
+
+  ipcMain.handle('db:updatePortfolio', (_event, id: unknown, updates: unknown) => {
+    if (typeof id !== 'number' || !Number.isInteger(id) || id <= 0) throw new Error('Invalid portfolio ID')
+    if (!updates || typeof updates !== 'object') throw new Error('Invalid updates')
+    const u = updates as Record<string, unknown>
+    if (u.name !== undefined && (typeof u.name !== 'string' || u.name.trim().length === 0 || u.name.length > 100)) {
+      throw new Error('Invalid portfolio name')
+    }
+    if (u.description !== undefined && u.description !== null && typeof u.description !== 'string') {
+      throw new Error('Invalid description')
+    }
+    if (u.defaultCostBasisMethod !== undefined) {
+      const validMethods = ['FIFO', 'LIFO', 'AVGCOST', 'SPECIFIC']
+      if (typeof u.defaultCostBasisMethod !== 'string' || !validMethods.includes(u.defaultCostBasisMethod)) {
+        throw new Error('Invalid cost basis method')
+      }
+    }
+    return updatePortfolio(id, updates as UpdatePortfolio)
+  })
+
+  ipcMain.handle('db:deletePortfolio', (_event, id: unknown) => {
+    if (typeof id !== 'number' || !Number.isInteger(id) || id <= 0) throw new Error('Invalid portfolio ID')
+    deletePortfolio(id)
   })
 }
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -9,7 +9,7 @@ export interface ElectronAPI {
   getQuotes: (tickers: string[]) => Promise<unknown[]>
   getHistoricalPrices: (ticker: string, from: string, to: string) => Promise<unknown[]>
   searchTicker: (query: string) => Promise<unknown[]>
-  getPositions: () => Promise<unknown[]>
+  getPositions: (portfolioId?: number) => Promise<unknown[]>
   getPortfolioSummary: () => Promise<unknown>
   getWatchlist: () => Promise<unknown[]>
   addWatchlistItem: (item: Record<string, unknown>) => Promise<unknown>
@@ -28,7 +28,7 @@ export interface ElectronAPI {
   addDividend: (input: Record<string, unknown>) => Promise<unknown>
   updateDividend: (id: string, updates: Record<string, unknown>) => Promise<unknown>
   deleteDividend: (id: string) => Promise<void>
-  getDividendSummary: () => Promise<unknown>
+  getDividendSummary: (portfolioId?: number) => Promise<unknown>
   getDividendHistory: (ticker: string, from?: string) => Promise<unknown[]>
   getDividendInfo: (ticker: string) => Promise<unknown>
   addOptionTransaction: (tx: Record<string, unknown>) => Promise<unknown>
@@ -36,6 +36,12 @@ export interface ElectronAPI {
   getOptionTransactions: (filters?: Record<string, unknown>) => Promise<unknown[]>
   getOptionPositions: (filters?: Record<string, unknown>) => Promise<unknown[]>
   getOptionsChain: (ticker: string, expirationDate?: string) => Promise<unknown>
+  // Portfolios
+  listPortfolios: () => Promise<unknown[]>
+  getPortfolio: (id: number) => Promise<unknown>
+  createPortfolio: (input: Record<string, unknown>) => Promise<unknown>
+  updatePortfolio: (id: number, updates: Record<string, unknown>) => Promise<unknown>
+  deletePortfolio: (id: number) => Promise<void>
 }
 
 const api: ElectronAPI = {
@@ -48,7 +54,7 @@ const api: ElectronAPI = {
   getHistoricalPrices: (ticker, from, to) =>
     ipcRenderer.invoke('market:getHistoricalPrices', ticker, from, to),
   searchTicker: (query) => ipcRenderer.invoke('market:searchTicker', query),
-  getPositions: () => ipcRenderer.invoke('db:getPositions'),
+  getPositions: (portfolioId) => ipcRenderer.invoke('db:getPositions', portfolioId),
   getPortfolioSummary: () => ipcRenderer.invoke('db:getPortfolioSummary'),
   getWatchlist: () => ipcRenderer.invoke('db:getWatchlist'),
   addWatchlistItem: (item) => ipcRenderer.invoke('db:addWatchlistItem', item),
@@ -67,18 +73,24 @@ const api: ElectronAPI = {
   addDividend: (input) => ipcRenderer.invoke('db:addDividend', input),
   updateDividend: (id, updates) => ipcRenderer.invoke('db:updateDividend', id, updates),
   deleteDividend: (id) => ipcRenderer.invoke('db:deleteDividend', id),
-  getDividendSummary: () => ipcRenderer.invoke('db:getDividendSummary'),
+  getDividendSummary: (portfolioId) => ipcRenderer.invoke('db:getDividendSummary', portfolioId),
   getDividendHistory: (ticker, from) => ipcRenderer.invoke('market:getDividendHistory', ticker, from),
   getDividendInfo: (ticker) => ipcRenderer.invoke('market:getDividendInfo', ticker),
-  getPortfolioTWR: (from, to) => ipcRenderer.invoke('db:getPortfolioTWR', from, to),
+  getPortfolioTWR: (from, to, portfolioId) => ipcRenderer.invoke('db:getPortfolioTWR', from, to, portfolioId),
   getBenchmarkTWR: (ticker, from, to) => ipcRenderer.invoke('db:getBenchmarkTWR', ticker, from, to),
   getBenchmarkStats: (benchmarkTicker, from, to) => ipcRenderer.invoke('db:getBenchmarkStats', benchmarkTicker, from, to),
-  getBenchmarkData: (benchmarkTicker, from, to) => ipcRenderer.invoke('db:getBenchmarkData', benchmarkTicker, from, to),
+  getBenchmarkData: (benchmarkTicker, from, to, portfolioId) => ipcRenderer.invoke('db:getBenchmarkData', benchmarkTicker, from, to, portfolioId),
   addOptionTransaction: (tx) => ipcRenderer.invoke('db:addOptionTransaction', tx),
   deleteOptionTransaction: (id) => ipcRenderer.invoke('db:deleteOptionTransaction', id),
   getOptionTransactions: (filters) => ipcRenderer.invoke('db:getOptionTransactions', filters),
   getOptionPositions: (filters) => ipcRenderer.invoke('db:getOptionPositions', filters),
-  getOptionsChain: (ticker, expirationDate) => ipcRenderer.invoke('market:getOptionsChain', ticker, expirationDate)
+  getOptionsChain: (ticker, expirationDate) => ipcRenderer.invoke('market:getOptionsChain', ticker, expirationDate),
+  // Portfolios
+  listPortfolios: () => ipcRenderer.invoke('db:listPortfolios'),
+  getPortfolio: (id) => ipcRenderer.invoke('db:getPortfolio', id),
+  createPortfolio: (input) => ipcRenderer.invoke('db:createPortfolio', input),
+  updatePortfolio: (id, updates) => ipcRenderer.invoke('db:updatePortfolio', id, updates),
+  deletePortfolio: (id) => ipcRenderer.invoke('db:deletePortfolio', id)
 }
 
 contextBridge.exposeInMainWorld('electronAPI', api)

--- a/src/components/Dividends/AddDividendModal.tsx
+++ b/src/components/Dividends/AddDividendModal.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useDividendStore } from '../../stores/dividendStore'
 import { useAppStore } from '../../stores/appStore'
+import { usePortfolioStore } from '../../stores/portfolioStore'
 import { TickerSearch } from '../Forms/TickerSearch'
+import { PortfolioSelect } from '../Portfolios/PortfolioSelect'
 import { INPUT_CLASS, INPUT_CLASS_NO_MONO, TEXTAREA_CLASS } from '../Forms/formUtils'
 import type { DividendType, SearchResult, Quote } from '../../types/index'
 
@@ -21,6 +23,7 @@ interface FormState {
   readonly notes: string
   readonly companyName: string
   readonly tickerValidated: boolean
+  readonly portfolioId: number | undefined
 }
 
 interface FormErrors {
@@ -37,6 +40,7 @@ function getTodayString(): string {
 
 function createInitialState(prefillTicker?: string, prefillShares?: number): FormState {
   const today = getTodayString()
+  const activePortfolioId = usePortfolioStore.getState().activePortfolioId
   return {
     ticker: prefillTicker ?? '',
     exDate: today,
@@ -46,7 +50,8 @@ function createInitialState(prefillTicker?: string, prefillShares?: number): For
     type: 'CASH',
     notes: '',
     companyName: '',
-    tickerValidated: !!prefillTicker
+    tickerValidated: !!prefillTicker,
+    portfolioId: activePortfolioId ?? undefined
   }
 }
 
@@ -180,7 +185,8 @@ export function AddDividendModal({ isOpen, onClose, prefillTicker }: AddDividend
         amountPerShare: parseFloat(form.amountPerShare),
         sharesAtDate: parseFloat(form.sharesAtDate),
         type: form.type,
-        notes: form.notes || undefined
+        notes: form.notes || undefined,
+        portfolioId: form.portfolioId
       })
 
       if (form.type === 'REINVESTED') {
@@ -251,6 +257,11 @@ export function AddDividendModal({ isOpen, onClose, prefillTicker }: AddDividend
               <p className="mt-1 text-xs text-sv-negative">{errors.ticker}</p>
             )}
           </div>
+
+          <PortfolioSelect
+            value={form.portfolioId}
+            onChange={(id) => updateField('portfolioId', id)}
+          />
 
           <div>
             <label className="block text-sm font-medium text-sv-text-secondary mb-1">Type</label>

--- a/src/components/Forms/AddOptionTransactionModal.tsx
+++ b/src/components/Forms/AddOptionTransactionModal.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useOptionsStore } from '../../stores/optionsStore'
+import { usePortfolioStore } from '../../stores/portfolioStore'
 import { TickerSearch } from './TickerSearch'
+import { PortfolioSelect } from '../Portfolios/PortfolioSelect'
 import { getMaxDateTimeLocal, getNowLocalDateTimeString, INPUT_CLASS, INPUT_CLASS_NO_MONO, TEXTAREA_CLASS } from './formUtils'
 import { buildOccSymbol } from '../../utils/occSymbol'
 import type { OptionAction, OptionType, SearchResult, Quote } from '../../types/index'
@@ -29,6 +31,7 @@ interface FormState {
   readonly companyName: string
   readonly currentPrice: number | null
   readonly tickerValidated: boolean
+  readonly portfolioId: number | undefined
 }
 
 interface FormErrors {
@@ -51,6 +54,7 @@ const OPTION_ACTIONS: ReadonlyArray<{ readonly value: OptionAction; readonly lab
 ]
 
 function createInitialState(props: AddOptionTransactionModalProps): FormState {
+  const activePortfolioId = usePortfolioStore.getState().activePortfolioId
   return {
     ticker: props.prefillTicker ?? '',
     optionAction: props.prefillAction ?? 'BUY_TO_OPEN',
@@ -64,7 +68,8 @@ function createInitialState(props: AddOptionTransactionModalProps): FormState {
     notes: '',
     companyName: '',
     currentPrice: null,
-    tickerValidated: !!props.prefillTicker
+    tickerValidated: !!props.prefillTicker,
+    portfolioId: activePortfolioId ?? undefined
   }
 }
 
@@ -211,7 +216,8 @@ export function AddOptionTransactionModal({
         price: parseFloat(form.price),
         date: new Date(form.date).toISOString(),
         fees: form.fees ? parseFloat(form.fees) : undefined,
-        notes: form.notes || undefined
+        notes: form.notes || undefined,
+        portfolioId: form.portfolioId
       })
       onClose()
     } catch (error) {
@@ -280,6 +286,11 @@ export function AddOptionTransactionModal({
               </div>
             )}
           </div>
+
+          <PortfolioSelect
+            value={form.portfolioId}
+            onChange={(id) => updateField('portfolioId', id)}
+          />
 
           {/* Option Type (Call/Put) */}
           <div>

--- a/src/components/Forms/AddTransactionModal.tsx
+++ b/src/components/Forms/AddTransactionModal.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useCallback } from 'react'
 import { useAppStore } from '../../stores/appStore'
+import { usePortfolioStore } from '../../stores/portfolioStore'
 import { TickerSearch } from './TickerSearch'
 import { LotPicker } from '../TaxLots/LotPicker'
+import { PortfolioSelect } from '../Portfolios/PortfolioSelect'
 import { getMaxDateTimeLocal, getNowLocalDateTimeString, INPUT_CLASS, INPUT_CLASS_NO_MONO, TEXTAREA_CLASS } from './formUtils'
 import type { TransactionType, SearchResult, Quote, CostBasisMethod } from '../../types/index'
 
@@ -22,6 +24,7 @@ interface FormState {
   readonly companyName: string
   readonly currentPrice: number | null
   readonly tickerValidated: boolean
+  readonly portfolioId: number | undefined
 }
 
 interface FormErrors {
@@ -32,6 +35,7 @@ interface FormErrors {
 }
 
 function createInitialState(prefillTicker?: string): FormState {
+  const activePortfolioId = usePortfolioStore.getState().activePortfolioId
   return {
     ticker: prefillTicker ?? '',
     type: 'BUY',
@@ -42,7 +46,8 @@ function createInitialState(prefillTicker?: string): FormState {
     notes: '',
     companyName: '',
     currentPrice: null,
-    tickerValidated: false
+    tickerValidated: false,
+    portfolioId: activePortfolioId ?? undefined
   }
 }
 
@@ -185,7 +190,8 @@ export function AddTransactionModal({ isOpen, onClose, prefillTicker }: AddTrans
           price: parseFloat(form.price),
           date: new Date(form.date).toISOString(),
           fees: form.fees ? parseFloat(form.fees) : undefined,
-          notes: form.notes || undefined
+          notes: form.notes || undefined,
+          portfolioId: form.portfolioId
         },
         isSpecificSell ? lotSelections : undefined
       )
@@ -258,6 +264,11 @@ export function AddTransactionModal({ isOpen, onClose, prefillTicker }: AddTrans
               </div>
             )}
           </div>
+
+          <PortfolioSelect
+            value={form.portfolioId}
+            onChange={(id) => updateField('portfolioId', id)}
+          />
 
           <div>
             <label className="block text-sm font-medium text-sv-text-secondary mb-1">Type</label>

--- a/src/components/Layout/Shell.tsx
+++ b/src/components/Layout/Shell.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useCallback } from 'react'
+import { useEffect, useCallback, useRef } from 'react'
 import { useAppStore, type ViewName } from '../../stores/appStore'
 import { useDividendStore } from '../../stores/dividendStore'
+import { usePortfolioStore } from '../../stores/portfolioStore'
 import { Sidebar } from './Sidebar'
 import { TopBar } from './TopBar'
 import { AddTransactionModal } from '../Forms/AddTransactionModal'
@@ -13,6 +14,7 @@ import { WatchlistView } from '../Watchlist/WatchlistView'
 import { DividendsView } from '../Views/DividendsView'
 import { OptionsView } from '../Views/OptionsView'
 import { BenchmarkView } from '../Views/BenchmarkView'
+import { PortfolioManagerView } from '../Portfolios/PortfolioManagerView'
 
 function renderView(activeView: ViewName) {
   switch (activeView) {
@@ -34,6 +36,8 @@ function renderView(activeView: ViewName) {
       return <DividendsView />
     case 'options':
       return <OptionsView />
+    case 'portfolios':
+      return <PortfolioManagerView />
     default:
       return <DashboardView />
   }
@@ -48,6 +52,8 @@ export function Shell() {
   const setModalOpen = useAppStore((state) => state.setModalOpen)
   const selectedTicker = useAppStore((state) => state.selectedTicker)
   const fetchDividendSummary = useDividendStore((state) => state.fetchDividendSummary)
+  const fetchPortfolios = usePortfolioStore((state) => state.fetchPortfolios)
+  const activePortfolioId = usePortfolioStore((state) => state.activePortfolioId)
 
   const handleCloseModal = useCallback(() => {
     setModalOpen(false)
@@ -89,6 +95,11 @@ export function Shell() {
   useEffect(() => {
     const loadInitialData = async () => {
       try {
+        await fetchPortfolios()
+      } catch {
+        // Portfolios are best-effort on first load
+      }
+      try {
         await fetchPositions()
       } catch {
         // Store actions throw with details; positions will remain empty
@@ -100,7 +111,28 @@ export function Shell() {
       }
     }
     loadInitialData()
-  }, [fetchPositions, fetchDividendSummary])
+  }, [fetchPositions, fetchDividendSummary, fetchPortfolios])
+
+  const isInitialMount = useRef(true)
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false
+      return
+    }
+    const refetchForPortfolio = async () => {
+      try {
+        await fetchPositions()
+      } catch {
+        // positions will remain stale
+      }
+      try {
+        await fetchDividendSummary()
+      } catch {
+        // summary is best-effort
+      }
+    }
+    refetchForPortfolio()
+  }, [activePortfolioId, fetchPositions, fetchDividendSummary])
 
   useEffect(() => {
     const tickers = positions.map((p) => p.ticker)

--- a/src/components/Layout/Sidebar.tsx
+++ b/src/components/Layout/Sidebar.tsx
@@ -122,6 +122,21 @@ function BenchmarkIcon() {
   )
 }
 
+function PortfoliosIcon() {
+  return (
+    <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M2 5C2 4.17 2.67 3.5 3.5 3.5H7L9 5.5H16.5C17.33 5.5 18 6.17 18 7V14.5C18 15.33 17.33 16 16.5 16H3.5C2.67 16 2 15.33 2 14.5V5Z"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path d="M7 10H13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  )
+}
+
 const NAV_ITEMS: ReadonlyArray<NavItem> = [
   { id: 'dashboard', label: 'Dashboard', icon: <DashboardIcon /> },
   { id: 'position-detail', label: 'Positions', icon: <PositionsIcon /> },
@@ -131,7 +146,8 @@ const NAV_ITEMS: ReadonlyArray<NavItem> = [
   { id: 'transactions', label: 'Transactions', icon: <TransactionsIcon /> },
   { id: 'dividends', label: 'Dividends', icon: <DividendsIcon /> },
   { id: 'closed-positions', label: 'Closed Trades', icon: <ClosedTradesIcon /> },
-  { id: 'watchlist', label: 'Watchlist', icon: <WatchlistIcon /> }
+  { id: 'watchlist', label: 'Watchlist', icon: <WatchlistIcon /> },
+  { id: 'portfolios', label: 'Portfolios', icon: <PortfoliosIcon /> }
 ]
 
 export function Sidebar() {

--- a/src/components/Layout/TopBar.tsx
+++ b/src/components/Layout/TopBar.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react'
 import { useAppStore } from '../../stores/appStore'
 import { usePortfolioStats } from '../../hooks/usePortfolioStats'
+import { PortfolioSwitcher } from '../Portfolios/PortfolioSwitcher'
 import {
   formatCurrency,
   formatSignedCurrency,
@@ -184,6 +185,7 @@ export function TopBar() {
   return (
     <header className="flex items-center justify-between h-14 px-4 bg-sv-surface border-b border-sv-border">
       <div className="flex items-center gap-6">
+        <PortfolioSwitcher />
         <div className="flex items-center gap-2">
           <span className="text-sv-text-secondary text-sm">Portfolio Value</span>
           <span className="font-mono text-lg font-semibold text-sv-text tabular-nums">

--- a/src/components/Portfolios/PortfolioManagerView.tsx
+++ b/src/components/Portfolios/PortfolioManagerView.tsx
@@ -1,0 +1,468 @@
+import { useState, useEffect, useCallback } from 'react'
+import { usePortfolioStore } from '../../stores/portfolioStore'
+import type { Portfolio, CostBasisMethod } from '../../types/index'
+
+const COST_BASIS_OPTIONS: ReadonlyArray<{ value: CostBasisMethod; label: string }> = [
+  { value: 'AVGCOST', label: 'Average Cost' },
+  { value: 'FIFO', label: 'FIFO' },
+  { value: 'LIFO', label: 'LIFO' },
+  { value: 'SPECIFIC', label: 'Specific ID' }
+]
+
+function PlusIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M8 3V13M3 8H13" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+    </svg>
+  )
+}
+
+function EditIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M9.5 2.5L11.5 4.5M2 12L2.5 9.5L10 2L12 4L3.5 12.5L2 12Z" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+function TrashIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M2.5 4H11.5M5 4V2.5H9V4M5.5 6V10.5M8.5 6V10.5M3.5 4L4 11.5H10L10.5 4" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+interface FormState {
+  readonly name: string
+  readonly description: string
+  readonly defaultCostBasisMethod: CostBasisMethod
+}
+
+const INITIAL_FORM: FormState = {
+  name: '',
+  description: '',
+  defaultCostBasisMethod: 'AVGCOST'
+}
+
+function CreatePortfolioForm({ onClose }: { readonly onClose: () => void }) {
+  const [form, setForm] = useState<FormState>({ ...INITIAL_FORM })
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const createPortfolio = usePortfolioStore((s) => s.createPortfolio)
+
+  const handleSubmit = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (form.name.trim().length === 0) {
+      setError('Portfolio name is required')
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      await createPortfolio({
+        name: form.name.trim(),
+        description: form.description.trim() || undefined,
+        defaultCostBasisMethod: form.defaultCostBasisMethod
+      })
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create portfolio')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }, [form, createPortfolio, onClose])
+
+  return (
+    <div className="bg-sv-elevated border border-sv-border rounded-lg p-5">
+      <h3 className="text-sm font-semibold text-sv-text mb-4">New Portfolio</h3>
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div>
+          <label className="block text-xs font-medium text-sv-text-secondary mb-1">Name</label>
+          <input
+            type="text"
+            value={form.name}
+            onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+            maxLength={100}
+            placeholder="e.g. Roth IRA"
+            className="w-full px-3 py-2 rounded-md bg-sv-surface border border-sv-border text-sv-text text-sm focus:outline-none focus:border-sv-accent"
+            autoFocus
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-sv-text-secondary mb-1">
+            Description <span className="text-sv-text-muted">(optional)</span>
+          </label>
+          <input
+            type="text"
+            value={form.description}
+            onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))}
+            maxLength={200}
+            placeholder="Optional description"
+            className="w-full px-3 py-2 rounded-md bg-sv-surface border border-sv-border text-sv-text text-sm focus:outline-none focus:border-sv-accent"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-sv-text-secondary mb-1">Default Cost Basis Method</label>
+          <select
+            value={form.defaultCostBasisMethod}
+            onChange={(e) => setForm((prev) => ({ ...prev, defaultCostBasisMethod: e.target.value as CostBasisMethod }))}
+            className="w-full px-3 py-2 rounded-md bg-sv-surface border border-sv-border text-sv-text text-sm focus:outline-none focus:border-sv-accent"
+          >
+            {COST_BASIS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+
+        {error && (
+          <div className="px-3 py-2 rounded-md bg-sv-negative/10 border border-sv-negative/20">
+            <p className="text-xs text-sv-negative">{error}</p>
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 pt-1">
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="px-4 py-2 text-sm font-medium text-white bg-sv-accent rounded-md hover:brightness-110 transition-all cursor-pointer disabled:opacity-50"
+          >
+            {isSubmitting ? 'Creating...' : 'Create'}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-sv-text-secondary bg-sv-surface border border-sv-border rounded-md hover:text-sv-text transition-colors cursor-pointer"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+function EditPortfolioForm({
+  portfolio,
+  onClose
+}: {
+  readonly portfolio: Portfolio
+  readonly onClose: () => void
+}) {
+  const [form, setForm] = useState<FormState>({
+    name: portfolio.name,
+    description: portfolio.description ?? '',
+    defaultCostBasisMethod: portfolio.defaultCostBasisMethod
+  })
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const updatePortfolio = usePortfolioStore((s) => s.updatePortfolio)
+
+  const handleSubmit = useCallback(async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+
+    if (form.name.trim().length === 0) {
+      setError('Portfolio name is required')
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      await updatePortfolio(portfolio.id, {
+        name: form.name.trim(),
+        description: form.description.trim() || null,
+        defaultCostBasisMethod: form.defaultCostBasisMethod
+      })
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to update portfolio')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }, [form, portfolio.id, updatePortfolio, onClose])
+
+  return (
+    <div className="bg-sv-elevated border border-sv-border rounded-lg p-5">
+      <h3 className="text-sm font-semibold text-sv-text mb-4">Edit Portfolio</h3>
+      <form onSubmit={handleSubmit} className="space-y-3">
+        <div>
+          <label className="block text-xs font-medium text-sv-text-secondary mb-1">Name</label>
+          <input
+            type="text"
+            value={form.name}
+            onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
+            maxLength={100}
+            className="w-full px-3 py-2 rounded-md bg-sv-surface border border-sv-border text-sv-text text-sm focus:outline-none focus:border-sv-accent"
+            autoFocus
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-sv-text-secondary mb-1">
+            Description <span className="text-sv-text-muted">(optional)</span>
+          </label>
+          <input
+            type="text"
+            value={form.description}
+            onChange={(e) => setForm((prev) => ({ ...prev, description: e.target.value }))}
+            maxLength={200}
+            className="w-full px-3 py-2 rounded-md bg-sv-surface border border-sv-border text-sv-text text-sm focus:outline-none focus:border-sv-accent"
+          />
+        </div>
+        <div>
+          <label className="block text-xs font-medium text-sv-text-secondary mb-1">Default Cost Basis Method</label>
+          <select
+            value={form.defaultCostBasisMethod}
+            onChange={(e) => setForm((prev) => ({ ...prev, defaultCostBasisMethod: e.target.value as CostBasisMethod }))}
+            className="w-full px-3 py-2 rounded-md bg-sv-surface border border-sv-border text-sv-text text-sm focus:outline-none focus:border-sv-accent"
+          >
+            {COST_BASIS_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+
+        {error && (
+          <div className="px-3 py-2 rounded-md bg-sv-negative/10 border border-sv-negative/20">
+            <p className="text-xs text-sv-negative">{error}</p>
+          </div>
+        )}
+
+        <div className="flex items-center gap-2 pt-1">
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="px-4 py-2 text-sm font-medium text-white bg-sv-accent rounded-md hover:brightness-110 transition-all cursor-pointer disabled:opacity-50"
+          >
+            {isSubmitting ? 'Saving...' : 'Save'}
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-sv-text-secondary bg-sv-surface border border-sv-border rounded-md hover:text-sv-text transition-colors cursor-pointer"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}
+
+function DeleteConfirmation({
+  portfolio,
+  onClose
+}: {
+  readonly portfolio: Portfolio
+  readonly onClose: () => void
+}) {
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const deletePortfolio = usePortfolioStore((s) => s.deletePortfolio)
+
+  const handleDelete = useCallback(async () => {
+    setIsDeleting(true)
+    setError(null)
+    try {
+      await deletePortfolio(portfolio.id)
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete portfolio')
+    } finally {
+      setIsDeleting(false)
+    }
+  }, [portfolio.id, deletePortfolio, onClose])
+
+  return (
+    <div className="bg-sv-elevated border border-sv-negative/30 rounded-lg p-5">
+      <h3 className="text-sm font-semibold text-sv-negative mb-2">Delete Portfolio</h3>
+      <p className="text-sm text-sv-text-secondary mb-1">
+        Are you sure you want to delete <span className="font-semibold text-sv-text">{portfolio.name}</span>?
+      </p>
+      <p className="text-xs text-sv-text-muted mb-4">
+        This will permanently delete all transactions, tax lots, and dividends in this portfolio.
+        This action cannot be undone.
+      </p>
+
+      {error && (
+        <div className="px-3 py-2 rounded-md bg-sv-negative/10 border border-sv-negative/20 mb-3">
+          <p className="text-xs text-sv-negative">{error}</p>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={isDeleting}
+          className="px-4 py-2 text-sm font-medium text-white bg-sv-negative rounded-md hover:brightness-110 transition-all cursor-pointer disabled:opacity-50"
+        >
+          {isDeleting ? 'Deleting...' : 'Delete Portfolio'}
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="px-4 py-2 text-sm font-medium text-sv-text-secondary bg-sv-surface border border-sv-border rounded-md hover:text-sv-text transition-colors cursor-pointer"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  )
+}
+
+function PortfolioCard({
+  portfolio,
+  onEdit,
+  onDelete
+}: {
+  readonly portfolio: Portfolio
+  readonly onEdit: () => void
+  readonly onDelete: () => void
+}) {
+  const costBasisLabel = COST_BASIS_OPTIONS.find((o) => o.value === portfolio.defaultCostBasisMethod)?.label ?? portfolio.defaultCostBasisMethod
+
+  return (
+    <div className="bg-sv-surface border border-sv-border rounded-lg p-4 flex items-start justify-between gap-4">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2 mb-1">
+          <h3 className="text-sm font-semibold text-sv-text truncate">{portfolio.name}</h3>
+          {portfolio.isDefault && (
+            <span className="shrink-0 px-1.5 py-0.5 text-[10px] font-medium text-sv-accent bg-sv-accent/10 rounded">
+              DEFAULT
+            </span>
+          )}
+        </div>
+        {portfolio.description && (
+          <p className="text-xs text-sv-text-muted mb-2 truncate">{portfolio.description}</p>
+        )}
+        <div className="flex items-center gap-4 text-xs text-sv-text-muted">
+          <span>Cost Basis: <span className="text-sv-text-secondary">{costBasisLabel}</span></span>
+          <span>Created: <span className="text-sv-text-secondary">{new Date(portfolio.createdAt).toLocaleDateString()}</span></span>
+        </div>
+      </div>
+
+      <div className="flex items-center gap-1 shrink-0">
+        <button
+          type="button"
+          onClick={onEdit}
+          className="p-1.5 rounded text-sv-text-muted hover:text-sv-accent hover:bg-sv-elevated transition-colors cursor-pointer"
+          title="Edit portfolio"
+        >
+          <EditIcon />
+        </button>
+        {!portfolio.isDefault && (
+          <button
+            type="button"
+            onClick={onDelete}
+            className="p-1.5 rounded text-sv-text-muted hover:text-sv-negative hover:bg-sv-negative/10 transition-colors cursor-pointer"
+            title="Delete portfolio"
+          >
+            <TrashIcon />
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export function PortfolioManagerView() {
+  const portfolios = usePortfolioStore((s) => s.portfolios)
+  const portfoliosLoading = usePortfolioStore((s) => s.portfoliosLoading)
+  const fetchPortfolios = usePortfolioStore((s) => s.fetchPortfolios)
+
+  const [showCreate, setShowCreate] = useState(false)
+  const [editingId, setEditingId] = useState<number | null>(null)
+  const [deletingId, setDeletingId] = useState<number | null>(null)
+
+  useEffect(() => {
+    fetchPortfolios().catch(() => {})
+  }, [fetchPortfolios])
+
+  const editingPortfolio = editingId !== null ? portfolios.find((p) => p.id === editingId) ?? null : null
+  const deletingPortfolio = deletingId !== null ? portfolios.find((p) => p.id === deletingId) ?? null : null
+
+  return (
+    <div className="max-w-2xl">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-xl font-semibold text-sv-text">Portfolios</h1>
+          <p className="text-sm text-sv-text-muted mt-0.5">
+            Manage your investment portfolios
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            setShowCreate(true)
+            setEditingId(null)
+            setDeletingId(null)
+          }}
+          className="
+            flex items-center gap-1.5 px-3 py-2 rounded-md
+            bg-sv-accent text-white text-sm font-medium
+            hover:brightness-110 transition-all cursor-pointer
+          "
+        >
+          <PlusIcon />
+          <span>New Portfolio</span>
+        </button>
+      </div>
+
+      {showCreate && (
+        <div className="mb-4">
+          <CreatePortfolioForm onClose={() => setShowCreate(false)} />
+        </div>
+      )}
+
+      {editingPortfolio && (
+        <div className="mb-4">
+          <EditPortfolioForm
+            portfolio={editingPortfolio}
+            onClose={() => setEditingId(null)}
+          />
+        </div>
+      )}
+
+      {deletingPortfolio && (
+        <div className="mb-4">
+          <DeleteConfirmation
+            portfolio={deletingPortfolio}
+            onClose={() => setDeletingId(null)}
+          />
+        </div>
+      )}
+
+      {portfoliosLoading && portfolios.length === 0 ? (
+        <div className="text-center py-12 text-sv-text-muted text-sm">
+          Loading portfolios...
+        </div>
+      ) : portfolios.length === 0 ? (
+        <div className="text-center py-12 text-sv-text-muted text-sm">
+          No portfolios found. Create one to get started.
+        </div>
+      ) : (
+        <div className="space-y-2">
+          {portfolios.map((portfolio) => (
+            <PortfolioCard
+              key={portfolio.id}
+              portfolio={portfolio}
+              onEdit={() => {
+                setEditingId(portfolio.id)
+                setShowCreate(false)
+                setDeletingId(null)
+              }}
+              onDelete={() => {
+                setDeletingId(portfolio.id)
+                setShowCreate(false)
+                setEditingId(null)
+              }}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/Portfolios/PortfolioSelect.tsx
+++ b/src/components/Portfolios/PortfolioSelect.tsx
@@ -1,0 +1,34 @@
+import { usePortfolioStore } from '../../stores/portfolioStore'
+
+interface PortfolioSelectProps {
+  readonly value: number | undefined
+  readonly onChange: (portfolioId: number) => void
+}
+
+export function PortfolioSelect({ value, onChange }: PortfolioSelectProps) {
+  const portfolios = usePortfolioStore((s) => s.portfolios)
+  const activePortfolioId = usePortfolioStore((s) => s.activePortfolioId)
+
+  const effectiveValue = value ?? activePortfolioId ?? portfolios.find((p) => p.isDefault)?.id
+
+  if (portfolios.length <= 1) {
+    return null
+  }
+
+  return (
+    <div>
+      <label className="block text-sm font-medium text-sv-text-secondary mb-1">Portfolio</label>
+      <select
+        value={effectiveValue ?? ''}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="w-full px-3 py-2 rounded-md bg-sv-surface border border-sv-border text-sv-text text-sm focus:outline-none focus:border-sv-accent font-mono"
+      >
+        {portfolios.map((p) => (
+          <option key={p.id} value={p.id}>
+            {p.name}{p.isDefault ? ' (default)' : ''}
+          </option>
+        ))}
+      </select>
+    </div>
+  )
+}

--- a/src/components/Portfolios/PortfolioSwitcher.tsx
+++ b/src/components/Portfolios/PortfolioSwitcher.tsx
@@ -1,0 +1,156 @@
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { usePortfolioStore } from '../../stores/portfolioStore'
+
+function ChevronDownIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+function FolderIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path
+        d="M1.5 3.5C1.5 2.95 1.95 2.5 2.5 2.5H5L6.5 4H11.5C12.05 4 12.5 4.45 12.5 5V10.5C12.5 11.05 12.05 11.5 11.5 11.5H2.5C1.95 11.5 1.5 11.05 1.5 10.5V3.5Z"
+        stroke="currentColor"
+        strokeWidth="1.2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}
+
+function CheckIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <path d="M2 6L5 9L10 3" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+    </svg>
+  )
+}
+
+export function PortfolioSwitcher() {
+  const [isOpen, setIsOpen] = useState(false)
+  const dropdownRef = useRef<HTMLDivElement>(null)
+
+  const portfolios = usePortfolioStore((s) => s.portfolios)
+  const activePortfolioId = usePortfolioStore((s) => s.activePortfolioId)
+  const setActivePortfolioId = usePortfolioStore((s) => s.setActivePortfolioId)
+
+  const activePortfolio = activePortfolioId !== null
+    ? portfolios.find((p) => p.id === activePortfolioId)
+    : null
+
+  const displayName = activePortfolio ? activePortfolio.name : 'All Portfolios'
+
+  const handleSelect = useCallback((id: number | null) => {
+    setActivePortfolioId(id)
+    setIsOpen(false)
+  }, [setActivePortfolioId])
+
+  useEffect(() => {
+    function handleClickOutside(event: MouseEvent) {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false)
+      }
+    }
+
+    if (isOpen) {
+      document.addEventListener('mousedown', handleClickOutside)
+    }
+    return () => document.removeEventListener('mousedown', handleClickOutside)
+  }, [isOpen])
+
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape' && isOpen) {
+        setIsOpen(false)
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [isOpen])
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      <button
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+        className="
+          flex items-center gap-1.5 px-2.5 py-1 rounded-md
+          text-sm font-medium text-sv-text-secondary
+          hover:text-sv-text hover:bg-sv-elevated
+          transition-colors duration-150 cursor-pointer
+          border border-sv-border
+        "
+      >
+        <FolderIcon />
+        <span className="max-w-[140px] truncate">{displayName}</span>
+        <ChevronDownIcon />
+      </button>
+
+      {isOpen && (
+        <div className="
+          absolute top-full left-0 mt-1 z-50
+          min-w-[200px] max-w-[280px]
+          bg-sv-elevated border border-sv-border rounded-lg shadow-xl
+          py-1 overflow-hidden
+        ">
+          <button
+            type="button"
+            onClick={() => handleSelect(null)}
+            className={`
+              flex items-center justify-between w-full px-3 py-2 text-sm
+              transition-colors duration-100 cursor-pointer
+              ${activePortfolioId === null
+                ? 'text-sv-accent bg-sv-accent/10'
+                : 'text-sv-text hover:bg-sv-surface'
+              }
+            `}
+          >
+            <span className="font-medium">All Portfolios</span>
+            {activePortfolioId === null && <CheckIcon />}
+          </button>
+
+          {portfolios.length > 0 && (
+            <div className="border-t border-sv-border my-1" />
+          )}
+
+          {portfolios.map((portfolio) => (
+            <button
+              key={portfolio.id}
+              type="button"
+              onClick={() => handleSelect(portfolio.id)}
+              className={`
+                flex items-center justify-between w-full px-3 py-2 text-sm
+                transition-colors duration-100 cursor-pointer
+                ${activePortfolioId === portfolio.id
+                  ? 'text-sv-accent bg-sv-accent/10'
+                  : 'text-sv-text hover:bg-sv-surface'
+                }
+              `}
+            >
+              <div className="flex flex-col items-start min-w-0">
+                <span className="font-medium truncate max-w-[200px]">
+                  {portfolio.name}
+                  {portfolio.isDefault && (
+                    <span className="ml-1.5 text-[10px] text-sv-text-muted font-normal">(default)</span>
+                  )}
+                </span>
+                {portfolio.description && (
+                  <span className="text-xs text-sv-text-muted truncate max-w-[200px]">
+                    {portfolio.description}
+                  </span>
+                )}
+              </div>
+              {activePortfolioId === portfolio.id && <CheckIcon />}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/Positions/PositionDetail.tsx
+++ b/src/components/Positions/PositionDetail.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { formatDistanceToNow, parseISO } from 'date-fns'
 import { useAppStore } from '../../stores/appStore'
+import { usePortfolioStore } from '../../stores/portfolioStore'
 import { useMarketData } from '../../hooks/useMarketData'
 import { useDividends, useDividendInfo } from '../../hooks/useDividends'
 import { PriceChart } from '../Charts/PriceChart'
@@ -179,11 +180,13 @@ function PositionDetailInner({
   const dividendInfo = useDividendInfo(ticker)
   const [dividendModalOpen, setDividendModalOpen] = useState(false)
 
+  const activePortfolioId = usePortfolioStore((s) => s.activePortfolioId)
+
   useEffect(() => {
     let cancelled = false
     setTxLoading(true)
     window.electronAPI
-      .getTransactions({ ticker })
+      .getTransactions({ ticker, ...(activePortfolioId !== null ? { portfolioId: activePortfolioId } : {}) })
       .then((txs) => {
         if (!cancelled) setTransactions(txs)
       })
@@ -196,7 +199,7 @@ function PositionDetailInner({
         if (!cancelled) setTxLoading(false)
       })
     return () => { cancelled = true }
-  }, [ticker, setTransactions, setTxLoading])
+  }, [ticker, activePortfolioId, setTransactions, setTxLoading])
 
   useEffect(() => {
     fetchTaxLots(ticker).catch(() => {})

--- a/src/components/Views/TransactionsView.tsx
+++ b/src/components/Views/TransactionsView.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useAppStore } from '../../stores/appStore'
+import { usePortfolioStore } from '../../stores/portfolioStore'
 import { useFilters } from '../../hooks/useFilters'
 import { EditTransactionModal } from '../Forms/EditTransactionModal'
 import { DeleteConfirmDialog } from '../Forms/DeleteConfirmDialog'
@@ -113,16 +114,20 @@ export function TransactionsView() {
   const [editingTx, setEditingTx] = useState<Transaction | null>(null)
   const [deletingTx, setDeletingTx] = useState<Transaction | null>(null)
 
+  const activePortfolioId = usePortfolioStore((s) => s.activePortfolioId)
+
   const loadTransactions = useCallback(async () => {
     try {
-      const data = await window.electronAPI.getTransactions()
+      const data = await window.electronAPI.getTransactions(
+        activePortfolioId !== null ? { portfolioId: activePortfolioId } : undefined
+      )
       setTransactions(data)
     } catch (error) {
       throw new Error(
         `Failed to load transactions: ${error instanceof Error ? error.message : String(error)}`
       )
     }
-  }, [])
+  }, [activePortfolioId])
 
   useEffect(() => {
     loadTransactions()

--- a/src/stores/appStore.ts
+++ b/src/stores/appStore.ts
@@ -1,7 +1,8 @@
 import { create } from 'zustand'
 import type { Position, Quote, NewTransaction, TaxLot, CostBasisMethod, TaxReportSummary } from '../types/index'
+import { usePortfolioStore } from './portfolioStore'
 
-export type ViewName = 'dashboard' | 'position-detail' | 'compare' | 'transactions' | 'closed-positions' | 'watchlist' | 'dividends' | 'options' | 'benchmark'
+export type ViewName = 'dashboard' | 'position-detail' | 'compare' | 'transactions' | 'closed-positions' | 'watchlist' | 'dividends' | 'options' | 'benchmark' | 'portfolios'
 export type GainStatus = 'all' | 'winners' | 'losers'
 
 export interface FilterState {
@@ -73,7 +74,8 @@ export const useAppStore = create<AppStore>()((set, get) => ({
   fetchPositions: async () => {
     set({ positionsLoading: true })
     try {
-      const positions = await window.electronAPI.getPositions()
+      const portfolioId = usePortfolioStore.getState().activePortfolioId
+      const positions = await window.electronAPI.getPositions(portfolioId ?? undefined)
       set({ positions, positionsLoading: false })
     } catch (error) {
       set({ positionsLoading: false })

--- a/src/stores/benchmarkStore.ts
+++ b/src/stores/benchmarkStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import type { TWRDataPoint, BenchmarkStats, BenchmarkTimeRange } from '../types/index'
+import { usePortfolioStore } from './portfolioStore'
 
 interface BenchmarkState {
   readonly benchmarkTicker: string
@@ -66,7 +67,8 @@ export const useBenchmarkStore = create<BenchmarkStore>()((set, get) => ({
       await window.electronAPI.getHistoricalPrices(benchmarkTicker, from, to)
 
       // Single IPC call computes portfolio TWR, benchmark TWR, and stats together
-      const data = await window.electronAPI.getBenchmarkData(benchmarkTicker, from, to)
+      const portfolioId = usePortfolioStore.getState().activePortfolioId
+      const data = await window.electronAPI.getBenchmarkData(benchmarkTicker, from, to, portfolioId ?? undefined)
 
       set({
         portfolioTWR: data.portfolioTWR,

--- a/src/stores/dividendStore.ts
+++ b/src/stores/dividendStore.ts
@@ -6,6 +6,7 @@ import type {
   PortfolioDividendSummary,
   DividendInfo
 } from '../types/index'
+import { usePortfolioStore } from './portfolioStore'
 
 interface DividendState {
   readonly dividends: ReadonlyArray<Dividend>
@@ -36,7 +37,12 @@ export const useDividendStore = create<DividendStore>()((set, get) => ({
   fetchDividends: async (filters?: DividendFilters) => {
     set({ dividendsLoading: true })
     try {
-      const dividends = await window.electronAPI.getDividends(filters) as Dividend[]
+      const portfolioId = usePortfolioStore.getState().activePortfolioId
+      const mergedFilters: DividendFilters = {
+        ...filters,
+        ...(portfolioId !== null ? { portfolioId } : {})
+      }
+      const dividends = await window.electronAPI.getDividends(mergedFilters) as Dividend[]
       set({ dividends, dividendsLoading: false })
     } catch (error) {
       set({ dividendsLoading: false })
@@ -87,7 +93,8 @@ export const useDividendStore = create<DividendStore>()((set, get) => ({
   fetchDividendSummary: async () => {
     set({ summaryLoading: true })
     try {
-      const summary = await window.electronAPI.getDividendSummary() as PortfolioDividendSummary
+      const portfolioId = usePortfolioStore.getState().activePortfolioId
+      const summary = await window.electronAPI.getDividendSummary(portfolioId ?? undefined) as PortfolioDividendSummary
       set({ summary, summaryLoading: false })
     } catch (error) {
       set({ summaryLoading: false })

--- a/src/stores/optionsStore.ts
+++ b/src/stores/optionsStore.ts
@@ -7,6 +7,7 @@ import type {
   OptionsChainData,
   PortfolioGreeks
 } from '../types/index'
+import { usePortfolioStore } from './portfolioStore'
 
 interface OptionsState {
   readonly optionPositions: ReadonlyArray<OptionPosition>
@@ -49,7 +50,12 @@ export const useOptionsStore = create<OptionsStore>()((set, get) => ({
   fetchOptionPositions: async (filters?: OptionPositionFilters) => {
     set({ optionPositionsLoading: true })
     try {
-      const positions = await window.electronAPI.getOptionPositions(filters) as OptionPosition[]
+      const portfolioId = usePortfolioStore.getState().activePortfolioId
+      const mergedFilters: OptionPositionFilters = {
+        ...filters,
+        ...(portfolioId !== null ? { portfolioId } : {})
+      }
+      const positions = await window.electronAPI.getOptionPositions(mergedFilters) as OptionPosition[]
       set({ optionPositions: positions, optionPositionsLoading: false })
     } catch (error) {
       set({ optionPositionsLoading: false })
@@ -61,7 +67,12 @@ export const useOptionsStore = create<OptionsStore>()((set, get) => ({
 
   fetchOptionTransactions: async (filters?: OptionPositionFilters) => {
     try {
-      const transactions = await window.electronAPI.getOptionTransactions(filters) as OptionTransaction[]
+      const portfolioId = usePortfolioStore.getState().activePortfolioId
+      const mergedFilters: OptionPositionFilters = {
+        ...filters,
+        ...(portfolioId !== null ? { portfolioId } : {})
+      }
+      const transactions = await window.electronAPI.getOptionTransactions(mergedFilters) as OptionTransaction[]
       set({ optionTransactions: transactions })
     } catch (error) {
       throw new Error(

--- a/src/stores/portfolioStore.ts
+++ b/src/stores/portfolioStore.ts
@@ -1,0 +1,87 @@
+import { create } from 'zustand'
+import type { Portfolio, NewPortfolio, UpdatePortfolio } from '../types/index'
+
+interface PortfolioState {
+  readonly portfolios: ReadonlyArray<Portfolio>
+  readonly portfoliosLoading: boolean
+  readonly activePortfolioId: number | null
+}
+
+interface PortfolioActions {
+  readonly fetchPortfolios: () => Promise<void>
+  readonly setActivePortfolioId: (id: number | null) => void
+  readonly createPortfolio: (input: NewPortfolio) => Promise<Portfolio>
+  readonly updatePortfolio: (id: number, updates: UpdatePortfolio) => Promise<Portfolio>
+  readonly deletePortfolio: (id: number) => Promise<void>
+  readonly getActivePortfolio: () => Portfolio | null
+}
+
+type PortfolioStore = PortfolioState & PortfolioActions
+
+export const usePortfolioStore = create<PortfolioStore>()((set, get) => ({
+  portfolios: [],
+  portfoliosLoading: false,
+  activePortfolioId: null,
+
+  fetchPortfolios: async () => {
+    set({ portfoliosLoading: true })
+    try {
+      const portfolios = await window.electronAPI.listPortfolios() as Portfolio[]
+      set({ portfolios, portfoliosLoading: false })
+    } catch (error) {
+      set({ portfoliosLoading: false })
+      throw new Error(
+        `Failed to fetch portfolios: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  },
+
+  setActivePortfolioId: (id: number | null) => {
+    set({ activePortfolioId: id })
+  },
+
+  createPortfolio: async (input: NewPortfolio) => {
+    try {
+      const portfolio = await window.electronAPI.createPortfolio(input) as Portfolio
+      await get().fetchPortfolios()
+      return portfolio
+    } catch (error) {
+      throw new Error(
+        `Failed to create portfolio: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  },
+
+  updatePortfolio: async (id: number, updates: UpdatePortfolio) => {
+    try {
+      const portfolio = await window.electronAPI.updatePortfolio(id, updates) as Portfolio
+      await get().fetchPortfolios()
+      return portfolio
+    } catch (error) {
+      throw new Error(
+        `Failed to update portfolio: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  },
+
+  deletePortfolio: async (id: number) => {
+    try {
+      await window.electronAPI.deletePortfolio(id)
+      const { activePortfolioId } = get()
+      if (activePortfolioId === id) {
+        set({ activePortfolioId: null })
+      }
+      await get().fetchPortfolios()
+    } catch (error) {
+      throw new Error(
+        `Failed to delete portfolio: ${error instanceof Error ? error.message : String(error)}`
+      )
+    }
+  },
+
+  getActivePortfolio: () => {
+    const { portfolios, activePortfolioId } = get()
+    if (activePortfolioId === null) return null
+    return portfolios.find((p) => p.id === activePortfolioId) ?? null
+  }
+}))

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -18,6 +18,28 @@ export type {
 
 export type CostBasisMethod = 'FIFO' | 'LIFO' | 'AVGCOST' | 'SPECIFIC'
 
+export interface Portfolio {
+  readonly id: number
+  readonly name: string
+  readonly description: string | null
+  readonly isDefault: boolean
+  readonly defaultCostBasisMethod: CostBasisMethod
+  readonly createdAt: string
+  readonly updatedAt: string
+}
+
+export interface NewPortfolio {
+  readonly name: string
+  readonly description?: string
+  readonly defaultCostBasisMethod?: CostBasisMethod
+}
+
+export interface UpdatePortfolio {
+  readonly name?: string
+  readonly description?: string | null
+  readonly defaultCostBasisMethod?: CostBasisMethod
+}
+
 export interface TaxLot {
   readonly id: string
   readonly transactionId: string
@@ -77,7 +99,7 @@ export interface ElectronAPI {
   getQuotes: (tickers: string[]) => Promise<Quote[]>
   getHistoricalPrices: (ticker: string, from: string, to: string) => Promise<PricePoint[]>
   searchTicker: (query: string) => Promise<SearchResult[]>
-  getPositions: () => Promise<Position[]>
+  getPositions: (portfolioId?: number) => Promise<Position[]>
   getPortfolioSummary: () => Promise<PortfolioSummary>
   getWatchlist: () => Promise<WatchlistItem[]>
   addWatchlistItem: (item: NewWatchlistItem) => Promise<WatchlistItem>
@@ -96,20 +118,26 @@ export interface ElectronAPI {
   addDividend: (dividend: NewDividend) => Promise<Dividend>
   updateDividend: (id: string, updates: Partial<NewDividend>) => Promise<Dividend>
   deleteDividend: (id: string) => Promise<void>
-  getDividendSummary: () => Promise<PortfolioDividendSummary>
+  getDividendSummary: (portfolioId?: number) => Promise<PortfolioDividendSummary>
   getDividendHistory: (ticker: string, from?: string) => Promise<DividendHistoryEntry[]>
   getDividendInfo: (ticker: string) => Promise<DividendInfo>
   // Benchmarking
-  getPortfolioTWR: (from: string, to: string) => Promise<TWRDataPoint[]>
+  getPortfolioTWR: (from: string, to: string, portfolioId?: number) => Promise<TWRDataPoint[]>
   getBenchmarkTWR: (ticker: string, from: string, to: string) => Promise<TWRDataPoint[]>
   getBenchmarkStats: (benchmarkTicker: string, from: string, to: string) => Promise<BenchmarkStats>
-  getBenchmarkData: (benchmarkTicker: string, from: string, to: string) => Promise<BenchmarkData>
+  getBenchmarkData: (benchmarkTicker: string, from: string, to: string, portfolioId?: number) => Promise<BenchmarkData>
   // Options
   addOptionTransaction: (tx: NewOptionTransaction) => Promise<OptionTransaction>
   deleteOptionTransaction: (id: string) => Promise<void>
   getOptionTransactions: (filters?: OptionPositionFilters) => Promise<OptionTransaction[]>
   getOptionPositions: (filters?: OptionPositionFilters) => Promise<OptionPosition[]>
   getOptionsChain: (ticker: string, expirationDate?: string) => Promise<OptionsChainData>
+  // Portfolios
+  listPortfolios: () => Promise<Portfolio[]>
+  createPortfolio: (portfolio: NewPortfolio) => Promise<Portfolio>
+  updatePortfolio: (id: number, updates: UpdatePortfolio) => Promise<Portfolio>
+  deletePortfolio: (id: number) => Promise<void>
+  getPortfolio: (id: number) => Promise<Portfolio>
 }
 
 export type TransactionType = 'BUY' | 'SELL'
@@ -125,6 +153,7 @@ export interface Dividend {
   readonly sharesAtDate: number
   readonly type: DividendType
   readonly linkedTransactionId: string | null
+  readonly portfolioId: number | null
   readonly notes: string | null
   readonly createdAt: string
   readonly updatedAt: string
@@ -138,6 +167,7 @@ export interface NewDividend {
   readonly sharesAtDate: number
   readonly type: DividendType
   readonly notes?: string
+  readonly portfolioId?: number
 }
 
 export interface DividendSummary {
@@ -185,6 +215,7 @@ export interface Transaction {
   readonly date: string
   readonly fees: number
   readonly notes: string | null
+  readonly portfolioId: number | null
   readonly created_at: string
   readonly updated_at: string
 }
@@ -197,6 +228,7 @@ export interface NewTransaction {
   readonly date: string
   readonly fees?: number
   readonly notes?: string
+  readonly portfolioId?: number
 }
 
 export type PositionStatus = 'OPEN' | 'CLOSED'
@@ -265,6 +297,7 @@ export interface TransactionFilters {
   readonly type?: TransactionType
   readonly fromDate?: string
   readonly toDate?: string
+  readonly portfolioId?: number
 }
 
 export interface WatchlistItem {
@@ -288,6 +321,7 @@ export interface DividendFilters {
   readonly fromDate?: string
   readonly toDate?: string
   readonly type?: DividendType
+  readonly portfolioId?: number
 }
 
 // Benchmarking types

--- a/src/types/options.ts
+++ b/src/types/options.ts
@@ -43,6 +43,7 @@ export interface NewOptionTransaction {
   readonly date: string
   readonly fees?: number
   readonly notes?: string
+  readonly portfolioId?: number
 }
 
 export interface OptionPosition {
@@ -70,6 +71,7 @@ export interface OptionPositionFilters {
   readonly ticker?: string
   readonly status?: OptionPositionStatus
   readonly optionType?: OptionType
+  readonly portfolioId?: number
 }
 
 export interface OptionsChainContract {


### PR DESCRIPTION
## Summary

- **New `portfolios` table** with auto-created Default portfolio and migration that backfills existing transactions/dividends
- **Portfolio CRUD** — create, rename, delete with cascade (transactions, tax lots, lot assignments, dividends)
- **Portfolio switcher** dropdown in TopBar with "All Portfolios" aggregate view
- **Portfolio manager view** accessible from sidebar for full portfolio management
- **All views scoped by active portfolio** — positions, transactions, dividends, options, benchmarks filter by selected portfolio
- **Portfolio selector** in transaction, dividend, and option forms (defaults to active portfolio)
- **Portfolio-scoped tax lot recomputation** prevents cross-portfolio lot mixing
- **Portfolio-scoped sell validation** prevents invalid cross-portfolio share sells

Closes #8, closes #21, closes #22

## Architecture

- DB: `portfolios` table + `portfolio_id` FK on `transactions` and `dividends` (indexed)
- IPC: 5 new handlers (`listPortfolios`, `getPortfolio`, `createPortfolio`, `updatePortfolio`, `deletePortfolio`)
- Store: new `portfolioStore.ts` with `activePortfolioId` (null = aggregate "All Portfolios")
- Existing stores (`appStore`, `dividendStore`, `optionsStore`, `benchmarkStore`) read `activePortfolioId` and pass to IPC
- Default portfolio cannot be deleted; cascade delete atomically removes all related data

## Files changed (27)

**New files (5):** `electron/db/portfolios.ts`, `src/stores/portfolioStore.ts`, `src/components/Portfolios/PortfolioSwitcher.tsx`, `src/components/Portfolios/PortfolioManagerView.tsx`, `src/components/Portfolios/PortfolioSelect.tsx`

**Modified (22):** Schema migration, IPC handlers, preload bridge, all stores, type definitions, layout components, form modals, transaction/position views

## Test plan

- [ ] App launches without errors; Default portfolio auto-created
- [ ] Existing transactions appear under Default portfolio
- [ ] Portfolio switcher shows "All Portfolios" + Default
- [ ] Create new portfolio (e.g. "Roth IRA") via Portfolios view
- [ ] Add transaction to specific portfolio; verify it only appears in that portfolio's view
- [ ] Switch between portfolios — dashboard, positions, transactions, dividends, options, benchmark all filter correctly
- [ ] "All Portfolios" aggregate shows combined data
- [ ] Delete non-default portfolio — confirm dialog, cascade deletes all data
- [ ] Cannot delete Default portfolio
- [ ] Sell validation respects portfolio scope (can't sell shares from another portfolio)
- [ ] Tax lot recomputation scoped per portfolio
- [ ] Benchmark TWR scoped per portfolio
- [ ] TypeScript: `npm run typecheck` passes
- [ ] Build: `npm run build` succeeds